### PR TITLE
Feature/require over import

### DIFF
--- a/spec/mocha.setup.js
+++ b/spec/mocha.setup.js
@@ -1,5 +1,5 @@
-import { expect } from 'chai';
-import jsdom from 'mocha-jsdom';
+const { expect } = require('chai');
+const jsdom = require('mocha-jsdom');
 
 global.expect = expect;
 global.jsdom = jsdom;

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -1,5 +1,5 @@
-import jsdom from 'mocha-jsdom';
-import ConstructorIO from '../../src/constructorio';
+const jsdom = require('mocha-jsdom');
+const ConstructorIO = require('../../src/constructorio');
 
 const validApiKey = 'testing';
 

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -1,8 +1,8 @@
-import jsdom from 'mocha-jsdom';
-import dotenv from 'dotenv';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import ConstructorIO from '../../../src/constructorio';
+const jsdom = require('mocha-jsdom');
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const ConstructorIO = require('../../../src/constructorio');
 
 chai.use(chaiAsPromised);
 dotenv.config();

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -157,22 +157,31 @@ describe('ConstructorIO - Autocomplete', () => {
       expect(() => autocomplete.getResults(null)).to.throw('query is a required parameter of type string');
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should throw an error when invalid results parameter is provided', (done) => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(autocomplete.getResults(query, { results: 'abc' })).to.eventually.be.rejected;
+      return expect(autocomplete.getResults(query, { results: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid filters parameter is provided', () => {
+    it('Should throw an error when invalid filters parameter is provided', (done) => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(autocomplete.getResults(query, { filters: 'abc' })).to.eventually.be.rejected;
+      return expect(autocomplete.getResults(query, { filters: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { autocomplete } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(autocomplete.getResults(query)).to.eventually.be.rejected;
+      return expect(autocomplete.getResults(query))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 });

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -143,13 +143,13 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it('Should throw an error when invalid query is provided', () => {
+    it('Should be rejected when invalid query is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => autocomplete.getResults([])).to.throw('query is a required parameter of type string');
     });
 
-    it('Should throw an error when no query is provided', () => {
+    it('Should be rejected when no query is provided', () => {
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
       });
@@ -157,31 +157,22 @@ describe('ConstructorIO - Autocomplete', () => {
       expect(() => autocomplete.getResults(null)).to.throw('query is a required parameter of type string');
     });
 
-    it('Should throw an error when invalid results parameter is provided', (done) => {
+    it('Should be rejected when invalid results parameter is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(autocomplete.getResults(query, { results: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(autocomplete.getResults(query, { results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid filters parameter is provided', (done) => {
+    it('Should be rejected when invalid filters parameter is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(autocomplete.getResults(query, { filters: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(autocomplete.getResults(query, { filters: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(autocomplete.getResults(query))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(autocomplete.getResults(query)).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -143,13 +143,13 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
-    it('Should be rejected when invalid query is provided', () => {
+    it('Should throw an error when invalid query is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => autocomplete.getResults([])).to.throw('query is a required parameter of type string');
     });
 
-    it('Should be rejected when no query is provided', () => {
+    it('Should throw an error when no query is provided', () => {
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
       });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -1,8 +1,8 @@
-import jsdom from 'mocha-jsdom';
-import dotenv from 'dotenv';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import ConstructorIO from '../../../src/constructorio';
+const jsdom = require('mocha-jsdom');
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const ConstructorIO = require('../../../src/constructorio');
 
 chai.use(chaiAsPromised);
 dotenv.config();

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -95,25 +95,25 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid itemIds are provided', () => {
+    it('Should be rejected when invalid itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getAlternativeItems({})).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when no itemIds are provided', () => {
+    it('Should be rejected when no itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getAlternativeItems()).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid results parameter is provided', () => {
+    it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', () => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
       return expect(recommendations.getAlternativeItems(itemId)).to.eventually.be.rejected;
@@ -201,25 +201,25 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid itemIds are provided', () => {
+    it('Should be rejected when invalid itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getComplementaryItems({})).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when no itemIds are provided', () => {
+    it('Should be rejected when no itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getComplementaryItems()).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid results parameter is provided', () => {
+    it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', () => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
       return expect(recommendations.getComplementaryItems(itemId)).to.eventually.be.rejected;
@@ -290,13 +290,13 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid results parameter is provided', () => {
+    it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getRecentlyViewedItems({ results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', () => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
       return expect(recommendations.getRecentlyViewedItems()).to.eventually.be.rejected;
@@ -367,13 +367,13 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid results parameter is provided', () => {
+    it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getUserFeaturedItems({ results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', () => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
       return expect(recommendations.getUserFeaturedItems()).to.eventually.be.rejected;

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -95,28 +95,40 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid itemIds are provided', () => {
+    it('Should throw an error when invalid itemIds are provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems({})).to.eventually.be.rejected;
+      return expect(recommendations.getAlternativeItems({}))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when no itemIds are provided', () => {
+    it('Should throw an error when no itemIds are provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems()).to.eventually.be.rejected;
+      return expect(recommendations.getAlternativeItems())
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should throw an error when invalid results parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
+      return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getAlternativeItems(itemId)).to.eventually.be.rejected;
+      return expect(recommendations.getAlternativeItems(itemId))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 
@@ -201,28 +213,40 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid itemIds are provided', () => {
+    it('Should throw an error when invalid itemIds are provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems({})).to.eventually.be.rejected;
+      return expect(recommendations.getComplementaryItems({}))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when no itemIds are provided', () => {
+    it('Should throw an error when no itemIds are provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems()).to.eventually.be.rejected;
+      return expect(recommendations.getComplementaryItems())
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should throw an error when invalid results parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
+      return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getComplementaryItems(itemId)).to.eventually.be.rejected;
+      return expect(recommendations.getComplementaryItems(itemId))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 
@@ -290,16 +314,22 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should throw an error when invalid results parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getRecentlyViewedItems({ results: 'abc' })).to.eventually.be.rejected;
+      return expect(recommendations.getRecentlyViewedItems({ results: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getRecentlyViewedItems()).to.eventually.be.rejected;
+      return expect(recommendations.getRecentlyViewedItems())
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 
@@ -367,16 +397,22 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should throw an error when invalid results parameter is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getUserFeaturedItems({ results: 'abc' })).to.eventually.be.rejected;
+      return expect(recommendations.getUserFeaturedItems({ results: 'abc' }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getUserFeaturedItems()).to.eventually.be.rejected;
+      return expect(recommendations.getUserFeaturedItems())
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -95,40 +95,28 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid itemIds are provided', (done) => {
+    it('Should throw an error when invalid itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems({}))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getAlternativeItems({})).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when no itemIds are provided', (done) => {
+    it('Should throw an error when no itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems())
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getAlternativeItems()).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid results parameter is provided', (done) => {
+    it('Should throw an error when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should throw an error when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getAlternativeItems(itemId))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getAlternativeItems(itemId)).to.eventually.be.rejected;
     });
   });
 
@@ -213,40 +201,28 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid itemIds are provided', (done) => {
+    it('Should throw an error when invalid itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems({}))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getComplementaryItems({})).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when no itemIds are provided', (done) => {
+    it('Should throw an error when no itemIds are provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems())
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getComplementaryItems()).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid results parameter is provided', (done) => {
+    it('Should throw an error when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should throw an error when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getComplementaryItems(itemId))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getComplementaryItems(itemId)).to.eventually.be.rejected;
     });
   });
 
@@ -314,22 +290,16 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid results parameter is provided', (done) => {
+    it('Should throw an error when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getRecentlyViewedItems({ results: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getRecentlyViewedItems({ results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should throw an error when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getRecentlyViewedItems())
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getRecentlyViewedItems()).to.eventually.be.rejected;
     });
   });
 
@@ -397,22 +367,16 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should throw an error when invalid results parameter is provided', (done) => {
+    it('Should throw an error when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getUserFeaturedItems({ results: 'abc' }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getUserFeaturedItems({ results: 'abc' })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should throw an error when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getUserFeaturedItems())
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(recommendations.getUserFeaturedItems()).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -169,99 +169,78 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it('Should throw an error when invalid query is provided', () => {
+    it('Should be rejected when invalid query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => search.getSearchResults([], { section })).to.throw('query is a required parameter of type string');
     });
 
-    it('Should throw an error when no query is provided', () => {
+    it('Should be rejected when no query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => search.getSearchResults(null, { section })).to.throw('query is a required parameter of type string');
     });
 
-    it('Should throw an error when invalid page parameter is provided', (done) => {
+    it('Should be rejected when invalid page parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         page: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid resultsPerPage parameter is provided', (done) => {
+    it('Should be rejected when invalid resultsPerPage parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         resultsPerPage: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid filters parameter is provided', (done) => {
+    it('Should be rejected when invalid filters parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         filters: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid sortBy parameter is provided', (done) => {
+    it('Should be rejected when invalid sortBy parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         sortBy: ['foo', 'bar'],
       };
 
-      return expect(search.getSearchResults(query, searchParams))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid sortOrder parameter is provided', (done) => {
+    it('Should be rejected when invalid sortOrder parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         sortOrder: 123,
       };
 
-      return expect(search.getSearchResults(query, searchParams))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid section parameter is provided', (done) => {
+    it('Should be rejected when invalid section parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(search.getSearchResults(query, { section: 123 }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, { section: 123 })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { search } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(search.getSearchResults(query, { section }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getSearchResults(query, { section })).to.eventually.be.rejected;
     });
   });
 
@@ -438,83 +417,68 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it('Should throw an error when invalid page parameter is provided', (done) => {
+    it('Should be rejected when invalid page parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         page: 'abc',
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid page parameter is provided', (done) => {
+    it('Should be rejected when invalid page parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         resultsPerPage: 'abc',
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid filters parameter is provided', (done) => {
+    it('Should be rejected when invalid filters parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: 'abc',
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid sortBy parameter is provided', (done) => {
+    it('Should be rejected when invalid sortBy parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortBy: { foo: 'bar' },
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid sortOrder parameter is provided', (done) => {
+    it('Should be rejected when invalid sortOrder parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortOrder: 'abc',
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid section parameter is provided', (done) => {
+    it('Should be rejected when invalid section parameter is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section: 123,
         filters: { group_id: groupId },
-      })).to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      })).to.eventually.be.rejected;
     });
 
-    it('Should throw an error when invalid apiKey is provided', (done) => {
+    it('Should be rejected when invalid apiKey is provided', () => {
       const { search } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(search.getBrowseResults(groupId, { section }))
-        .to.eventually.be.rejectedWith('BAD REQUEST')
-        .and.be.an.instanceOf(Error)
-        .notify(done);
+      return expect(search.getBrowseResults(groupId, { section })).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -181,66 +181,87 @@ describe('ConstructorIO - Search', () => {
       expect(() => search.getSearchResults(null, { section })).to.throw('query is a required parameter of type string');
     });
 
-    it('Should be rejected when invalid page parameter is provided', () => {
+    it('Should throw an error when invalid page parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         page: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, searchParams))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid resultsPerPage parameter is provided', () => {
+    it('Should throw an error when invalid resultsPerPage parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         resultsPerPage: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, searchParams))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid filters parameter is provided', () => {
+    it('Should throw an error when invalid filters parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         filters: 'abc',
       };
 
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, searchParams))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid sortBy parameter is provided', () => {
+    it('Should throw an error when invalid sortBy parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         sortBy: ['foo', 'bar'],
       };
 
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, searchParams))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid sortOrder parameter is provided', () => {
+    it('Should throw an error when invalid sortOrder parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const searchParams = {
         section,
         sortOrder: 123,
       };
 
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, searchParams))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid section parameter is provided', () => {
+    it('Should throw an error when invalid section parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(search.getSearchResults(query, { section: 123 })).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, { section: 123 }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(search.getSearchResults(query, { section })).to.eventually.be.rejected;
+      return expect(search.getSearchResults(query, { section }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 
@@ -417,68 +438,83 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it('Should be rejected when invalid page parameter is provided', () => {
+    it('Should throw an error when invalid page parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         page: 'abc',
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid page parameter is provided', () => {
+    it('Should throw an error when invalid page parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         resultsPerPage: 'abc',
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid filters parameter is provided', () => {
+    it('Should throw an error when invalid filters parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: 'abc',
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid sortBy parameter is provided', () => {
+    it('Should throw an error when invalid sortBy parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortBy: { foo: 'bar' },
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid sortOrder parameter is provided', () => {
+    it('Should throw an error when invalid sortOrder parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortOrder: 'abc',
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid section parameter is provided', () => {
+    it('Should throw an error when invalid section parameter is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getBrowseResults({
         section: 123,
         filters: { group_id: groupId },
-      })).to.eventually.be.rejected;
+      })).to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
 
-    it('Should be rejected when invalid apiKey is provided', () => {
+    it('Should throw an error when invalid apiKey is provided', (done) => {
       const { search } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(search.getBrowseResults(groupId, { section })).to.eventually.be.rejected;
+      return expect(search.getBrowseResults(groupId, { section }))
+        .to.eventually.be.rejectedWith('BAD REQUEST')
+        .and.be.an.instanceOf(Error)
+        .notify(done);
     });
   });
 });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -1,8 +1,8 @@
-import jsdom from 'mocha-jsdom';
-import dotenv from 'dotenv';
-import chai from 'chai';
-import chaiAsPromised from 'chai-as-promised';
-import ConstructorIO from '../../../src/constructorio';
+const jsdom = require('mocha-jsdom');
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const ConstructorIO = require('../../../src/constructorio');
 
 chai.use(chaiAsPromised);
 dotenv.config();

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -169,13 +169,13 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it('Should be rejected when invalid query is provided', () => {
+    it('Should throw an error when invalid query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => search.getSearchResults([], { section })).to.throw('query is a required parameter of type string');
     });
 
-    it('Should be rejected when no query is provided', () => {
+    it('Should throw an error when no query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(() => search.getSearchResults(null, { section })).to.throw('query is a required parameter of type string');

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -85,7 +85,7 @@ const autocomplete = (options) => {
             return response.json();
           }
 
-          throw response;
+          throw new Error(response.statusText);
         })
         .then((json) => {
           if (json.sections) {

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -85,7 +85,7 @@ const autocomplete = (options) => {
             return response.json();
           }
 
-          throw new Error(response.statusText);
+          throw response;
         })
         .then((json) => {
           if (json.sections) {

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -1,7 +1,7 @@
-/* eslint-disable import/prefer-default-export, object-curly-newline */
-import qs from 'qs';
-import fetchPonyfill from 'fetch-ponyfill';
-import Promise from 'es6-promise';
+/* eslint-disable object-curly-newline */
+const qs = require('qs');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 
 const { fetch } = fetchPonyfill({ Promise });
 
@@ -12,7 +12,7 @@ const { fetch } = fetchPonyfill({ Promise });
  * @inner
  * @returns {object}
  */
-export function autocomplete(options) {
+const autocomplete = (options) => {
   // Create URL from supplied query (term) and parameters
   const createAutocompleteUrl = (query, parameters) => {
     const { apiKey, version, serviceUrl, sessionId, clientId, segments, testCells } = options;
@@ -112,4 +112,8 @@ export function autocomplete(options) {
         });
     },
   };
-}
+};
+
+module.exports = {
+  autocomplete,
+};

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -64,7 +64,7 @@ const recommendations = (options) => {
         return response.json();
       }
 
-      throw response;
+      throw new Error(response.statusText);
     })
     .then((json) => {
       if (json.response && json.response.results) {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -64,7 +64,7 @@ const recommendations = (options) => {
         return response.json();
       }
 
-      throw new Error(response.statusText);
+      throw response;
     })
     .then((json) => {
       if (json.response && json.response.results) {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -1,7 +1,7 @@
-/* eslint-disable import/prefer-default-export, object-curly-newline, no-param-reassign */
-import qs from 'qs';
-import fetchPonyfill from 'fetch-ponyfill';
-import Promise from 'es6-promise';
+/* eslint-disable object-curly-newline, no-param-reassign */
+const qs = require('qs');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 
 const { fetch } = fetchPonyfill({ Promise });
 
@@ -12,7 +12,7 @@ const { fetch } = fetchPonyfill({ Promise });
  * @inner
  * @returns {object}
  */
-export function recommendations(options) {
+const recommendations = (options) => {
   // Create URL from supplied parameters
   const createRecommendationsUrl = (parameters, endpoint) => {
     const { apiKey, version, serviceUrl, sessionId, clientId, segments } = options;
@@ -138,4 +138,8 @@ export function recommendations(options) {
      */
     getUserFeaturedItems: (parameters) => requestAndProcessResponse(createRecommendationsUrl(parameters, 'user_featured_items'), 'user_featured_items'),
   };
-}
+};
+
+module.exports = {
+  recommendations,
+};

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/prefer-default-export, object-curly-newline */
-import qs from 'qs';
-import fetchPonyfill from 'fetch-ponyfill';
-import Promise from 'es6-promise';
+const qs = require('qs');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 
 const { fetch } = fetchPonyfill({ Promise });
 
@@ -12,7 +12,7 @@ const { fetch } = fetchPonyfill({ Promise });
  * @inner
  * @returns {object}
  */
-export function search(options) {
+const search = (options) => {
   // Create URL from supplied query (term) and parameters
   const createSearchUrl = (query, parameters) => {
     const { apiKey, version, serviceUrl, sessionId, clientId, segments, testCells } = options;
@@ -220,4 +220,8 @@ export function search(options) {
         });
     },
   };
-}
+};
+
+module.exports = {
+  search,
+};

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -161,7 +161,7 @@ const search = (options) => {
             return response.json();
           }
 
-          throw response;
+          throw new Error(response.statusText);
         })
         .then((json) => {
           if (json.response && json.response.results) {
@@ -201,7 +201,7 @@ const search = (options) => {
             return response.json();
           }
 
-          throw response;
+          throw new Error(response.statusText);
         })
         .then((json) => {
           if (json.response && json.response.results) {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -161,7 +161,7 @@ const search = (options) => {
             return response.json();
           }
 
-          throw new Error(response.statusText);
+          throw response;
         })
         .then((json) => {
           if (json.response && json.response.results) {
@@ -201,7 +201,7 @@ const search = (options) => {
             return response.json();
           }
 
-          throw new Error(response.statusText);
+          throw response;
         })
         .then((json) => {
           if (json.response && json.response.results) {


### PR DESCRIPTION
- `import` and `export` are only natively supported in Node 12. Revert to using `require` to increase compatibility with older versions of Node.

All tests pass. Code coverage is stable.