### PR TITLE
Feature/test request urls

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,9 @@
     "mocha": "^6.2.0",
     "mocha-jsdom": "^2.0.0",
     "nyc": "^14.1.1",
-    "pre-push": "^0.1.1"
+    "pre-push": "^0.1.1",
+    "sinon": "^7.5.0",
+    "sinon-chai": "^3.3.0"
   },
   "dependencies": {
     "@constructor-io/constructorio-id": "^2.1.1",

--- a/spec/mocha.helpers.js
+++ b/spec/mocha.helpers.js
@@ -1,0 +1,18 @@
+const qs = require('qs');
+
+// Extract query parameters as object from url
+const extractUrlParamsFromFetch = (fetch) => {
+  const lastCallArguments = fetch && fetch.args && fetch.args[fetch.args.length - 1];
+  const url = lastCallArguments[0];
+  const urlSplit = url && url.split('?');
+
+  if (urlSplit && urlSplit[1]) {
+    return qs.parse(urlSplit[1]);
+  }
+
+  return null;
+};
+
+module.exports = {
+  extractUrlParamsFromFetch,
+};

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -1,38 +1,62 @@
+/* eslint-disable no-unused-expressions */
 const jsdom = require('mocha-jsdom');
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 const ConstructorIO = require('../../../src/constructorio');
+const helpers = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 dotenv.config();
 
 const testApiKey = process.env.TEST_API_KEY;
+const { fetch } = fetchPonyfill({ Promise });
 
 describe('ConstructorIO - Autocomplete', () => {
+  const clientVersion = 'cio-mocha';
+  let fetchSpy;
+
   jsdom({
     url: 'http://localhost',
+  });
+
+  beforeEach(() => {
+    global.CLIENT_VERSION = 'cio-mocha';
+    fetchSpy = sinon.spy(fetch);
+  });
+
+  afterEach(() => {
+    delete global.CLIENT_VERSION;
+
+    fetchSpy = null;
   });
 
   describe('getResults', () => {
     const query = 'drill';
 
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
     it('Should return a response with a valid query', (done) => {
-      const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       autocomplete.getResults(query).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.term).to.equal(query);
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
         done();
       });
     });
@@ -42,13 +66,17 @@ describe('ConstructorIO - Autocomplete', () => {
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
         testCells,
+        fetch: fetchSpy,
       });
 
       autocomplete.getResults(query).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+        expect(requestedUrlParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
         done();
       });
     });
@@ -58,22 +86,30 @@ describe('ConstructorIO - Autocomplete', () => {
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       autocomplete.getResults(query).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.us).to.deep.equal(segments);
+        expect(requestedUrlParams).to.have.property('us').to.deep.equal(segments);
         done();
       });
     });
 
     it('Should return a response with a valid query, and results', (done) => {
       const results = 2;
-      const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       autocomplete.getResults(query, { results }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
         const sectionKeys = Object.keys(res.sections);
         let resultCount = 0;
 
@@ -88,6 +124,7 @@ describe('ConstructorIO - Autocomplete', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
         expect(resultCount).to.equal(results);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
         done();
       });
     });
@@ -97,27 +134,41 @@ describe('ConstructorIO - Autocomplete', () => {
         Products: 1,
         'Search Suggestions': 2,
       };
-      const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       autocomplete.getResults(query, { resultsPerSection }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results_Products).to.equal(resultsPerSection.Products.toString());
         expect(res.request['num_results_Search Suggestions']).to.equal(resultsPerSection['Search Suggestions'].toString());
+        expect(requestedUrlParams).to.have.property('num_results_Products').to.equal(resultsPerSection.Products.toString());
+        expect(requestedUrlParams).to.have.property('num_results_Search Suggestions').to.equal(resultsPerSection['Search Suggestions'].toString());
         done();
       });
     });
 
     it('Should return a response with a valid query, and filters', (done) => {
       const filters = { keywords: ['battery-powered'] };
-      const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       autocomplete.getResults(query, { filters }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.filters).to.deep.equal(filters);
+        expect(requestedUrlParams).to.have.property('filters');
+        expect(requestedUrlParams.filters).to.have.property('keywords').to.equal(Object.values(filters)[0][0]);
         done();
       });
     });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -1,53 +1,84 @@
+/* eslint-disable no-unused-expressions */
 const jsdom = require('mocha-jsdom');
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 const ConstructorIO = require('../../../src/constructorio');
+const helpers = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 dotenv.config();
 
 const testApiKey = process.env.TEST_API_KEY;
+const { fetch } = fetchPonyfill({ Promise });
 
 describe('ConstructorIO - Recommendations', () => {
+  const clientVersion = 'cio-mocha';
+  let fetchSpy;
+
   jsdom({
     url: 'http://localhost',
+  });
+
+  beforeEach(() => {
+    global.CLIENT_VERSION = 'cio-mocha';
+    fetchSpy = sinon.spy(fetch);
+  });
+
+  afterEach(() => {
+    delete global.CLIENT_VERSION;
+
+    fetchSpy = null;
   });
 
   describe('getAlternativeItems', () => {
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
     it('Should return a response with valid itemIds (singular)', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getAlternativeItems(itemId).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.equal(itemId);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestedUrlParams).to.have.property('item_id').to.equal(itemId);
         done();
       });
     });
 
     it('Should return a response with valid itemIds (multiple)', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getAlternativeItems(itemIds).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.deep.equal(itemIds);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
         done();
       });
     });
@@ -57,25 +88,35 @@ describe('ConstructorIO - Recommendations', () => {
       const { recommendations } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       recommendations.getAlternativeItems(itemId).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
         done();
       });
     });
 
     it('Should return a response with valid itemIds, and results', (done) => {
       const results = 2;
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getAlternativeItems(itemId, { results }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
         done();
       });
     });
@@ -124,36 +165,45 @@ describe('ConstructorIO - Recommendations', () => {
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
     it('Should return a response with valid itemIds (singular)', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getComplementaryItems(itemId).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.equal(itemId);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestedUrlParams).to.have.property('item_id').to.equal(itemId);
         done();
       });
     });
 
     it('Should return a response with valid itemIds (multiple)', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getComplementaryItems(itemIds).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.deep.equal(itemIds);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
         done();
       });
     });
@@ -163,25 +213,35 @@ describe('ConstructorIO - Recommendations', () => {
       const { recommendations } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       recommendations.getComplementaryItems(itemId).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
         done();
       });
     });
 
     it('Should return a response with valid itemIds, and results', (done) => {
       const results = 2;
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getComplementaryItems(itemId, { results }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
         done();
       });
     });
@@ -236,13 +296,22 @@ describe('ConstructorIO - Recommendations', () => {
     });
 
     it('Should return a response', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getRecentlyViewedItems().then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
         done();
       });
     });
@@ -252,25 +321,35 @@ describe('ConstructorIO - Recommendations', () => {
       const { recommendations } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       recommendations.getRecentlyViewedItems().then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
         done();
       });
     });
 
     it('Should return a response with valid results', (done) => {
       const results = 2;
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getRecentlyViewedItems({ results }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
         done();
       });
     });
@@ -313,13 +392,22 @@ describe('ConstructorIO - Recommendations', () => {
     });
 
     it('Should return a response', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getUserFeaturedItems().then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
         done();
       });
     });
@@ -329,25 +417,35 @@ describe('ConstructorIO - Recommendations', () => {
       const { recommendations } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       recommendations.getUserFeaturedItems().then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
+        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
         done();
       });
     });
 
     it('Should return a response with valid results', (done) => {
       const results = 2;
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       recommendations.getUserFeaturedItems({ results }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
         done();
       });
     });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -1,41 +1,64 @@
+/* eslint-disable no-unused-expressions */
 const jsdom = require('mocha-jsdom');
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const fetchPonyfill = require('fetch-ponyfill');
+const Promise = require('es6-promise');
 const ConstructorIO = require('../../../src/constructorio');
+const helpers = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 dotenv.config();
 
 const testApiKey = process.env.TEST_API_KEY;
+const { fetch } = fetchPonyfill({ Promise });
 
-describe('ConstructorIO - Search', () => {
-  jsdom({
-    url: 'http://localhost',
+describe.only('ConstructorIO - Search', () => {
+  const clientVersion = 'cio-mocha';
+  let fetchSpy;
+
+  jsdom({ url: 'http://localhost' });
+
+  beforeEach(() => {
+    global.CLIENT_VERSION = clientVersion;
+    fetchSpy = sinon.spy(fetch);
+  });
+
+  afterEach(() => {
+    delete global.CLIENT_VERSION;
+
+    fetchSpy = null;
   });
 
   describe('getSearchResults', () => {
     const query = 'drill';
     const section = 'Products';
 
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
     it('Should return a response with a valid query, and section', (done) => {
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, { section }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.term).to.equal(query);
         expect(res.request.section).to.equal(section);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('section').to.equal(section);
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
         done();
       });
     });
@@ -45,111 +68,150 @@ describe('ConstructorIO - Search', () => {
       const { search } = new ConstructorIO({
         apiKey: testApiKey,
         testCells,
+        fetch: fetchSpy,
       });
 
       search.getSearchResults(query, { section }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+        expect(requestedUrlParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
         done();
       });
     });
 
     it('Should return a response with a valid query, section and segments', (done) => {
-      const segments = ['segments'];
+      const segments = ['foo', 'bar'];
       const { search } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       search.getSearchResults(query, { section }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.us).to.deep.equal(segments);
+        expect(requestedUrlParams).to.have.property('us').to.deep.equal(segments);
         done();
       });
     });
 
     it('Should return a response with a valid query, section, and page', (done) => {
       const page = 1;
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, {
         section,
         page,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.page).to.equal(page);
+        expect(requestedUrlParams).to.have.property('page').to.equal(page.toString());
         done();
       });
     });
 
     it('Should return a response with a valid query, section, and resultsPerPage', (done) => {
       const resultsPerPage = 2;
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, {
         section,
         resultsPerPage,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results_per_page).to.equal(resultsPerPage);
         expect(res.response).to.have.property('results').to.be.an('array');
         expect(res.response.results.length).to.equal(resultsPerPage);
+        expect(requestedUrlParams).to.have.property('num_results_per_page').to.equal(resultsPerPage.toString());
         done();
       });
     });
 
     it('Should return a response with a valid query, section, and filters', (done) => {
       const filters = { keywords: ['battery-powered'] };
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, {
         section,
         filters,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.filters).to.deep.equal(filters);
+        expect(requestedUrlParams).to.have.property('filters');
+        expect(requestedUrlParams.filters).to.have.property('keywords').to.equal(Object.values(filters)[0][0]);
         done();
       });
     });
 
     it('Should return a response with a valid query, section, and sortBy', (done) => {
       const sortBy = 'relevance';
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, {
         section,
         sortBy,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.sort_by).to.deep.equal(sortBy);
+        expect(res.request.sort_by).to.equal(sortBy);
+        expect(requestedUrlParams).to.have.property('sort_by').to.equal(sortBy);
         done();
       });
     });
 
     it('Should return a response with a valid query, section, and sortOrder', (done) => {
       const sortOrder = 'ascending';
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getSearchResults(query, {
         section,
         sortOrder,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.sort_order).to.deep.equal(sortOrder);
+        expect(res.request.sort_order).to.equal(sortOrder);
+        expect(requestedUrlParams).to.have.property('sort_order').to.equal(sortOrder);
         done();
       });
     });
@@ -247,22 +309,20 @@ describe('ConstructorIO - Search', () => {
   describe('getBrowseResults', () => {
     const section = 'Products';
     const groupId = 'drill_collection';
-
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
+    const filters = { group_id: [groupId] };
 
     it('Should return a response with a valid group_id, and section', (done) => {
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
-        filters: { group_id: groupId },
+        filters,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
@@ -271,6 +331,13 @@ describe('ConstructorIO - Search', () => {
         expect(res.request.filters.group_id).to.include(groupId);
         expect(res.request.section).to.equal(section);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedUrlParams).to.have.property('key');
+        expect(requestedUrlParams).to.have.property('i');
+        expect(requestedUrlParams).to.have.property('s');
+        expect(requestedUrlParams).to.have.property('section').to.equal(section);
+        expect(requestedUrlParams).to.have.property('filters');
+        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
         done();
       });
     });
@@ -280,121 +347,160 @@ describe('ConstructorIO - Search', () => {
       const { search } = new ConstructorIO({
         apiKey: testApiKey,
         testCells,
+        fetch: fetchSpy,
       });
 
       search.getBrowseResults({
         section,
-        filters: { group_id: groupId },
+        filters,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
+        expect(requestedUrlParams).to.have.property(`ef-${Object.keys(testCells)[0]}`).to.equal(Object.values(testCells)[0]);
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section and segments', (done) => {
-      const segments = ['segments'];
+      const segments = ['foo', 'bar'];
       const { search } = new ConstructorIO({
         apiKey: testApiKey,
         segments,
+        fetch: fetchSpy,
       });
 
       search.getBrowseResults({
         section,
-        filters: { group_id: groupId },
+        filters,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.us).to.deep.equal(segments);
+        expect(requestedUrlParams).to.have.property('us').to.deep.equal(segments);
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section, and page', (done) => {
       const page = 1;
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
-        filters: { group_id: groupId },
+        filters,
         page,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.page).to.equal(page);
+        expect(requestedUrlParams).to.have.property('page').to.equal(page.toString());
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section, and resultsPerPage', (done) => {
       const resultsPerPage = 2;
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         resultsPerPage,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results_per_page).to.equal(resultsPerPage);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(requestedUrlParams).to.have.property('num_results_per_page').to.equal(resultsPerPage.toString());
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section, and additional filters', (done) => {
-      const filters = { keywords: ['battery-powered'] };
-      const combinedFilters = Object.assign({}, filters, { group_id: [groupId] });
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const additionalFilters = { keywords: ['battery-powered'] };
+      const combinedFilters = Object.assign({}, additionalFilters, filters);
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
         filters: combinedFilters,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.filters).to.deep.equal(combinedFilters);
+        expect(requestedUrlParams).to.have.property('filters');
+        expect(requestedUrlParams.filters).to.have.property('keywords').to.equal(Object.values(additionalFilters)[0][0]);
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section, and sortBy', (done) => {
       const sortBy = 'relevance';
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortBy,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.sort_by).to.deep.equal(sortBy);
+        expect(requestedUrlParams).to.have.property('sort_by').to.equal(sortBy);
         done();
       });
     });
 
     it('Should return a response with a valid group_id, section, and sortOrder', (done) => {
       const sortOrder = 'ascending';
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
 
       search.getBrowseResults({
         section,
         filters: { group_id: groupId },
         sortOrder,
       }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.sort_order).to.deep.equal(sortOrder);
+        expect(requestedUrlParams).to.have.property('sort_order').to.equal(sortOrder);
         done();
       });
     });

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -17,7 +17,7 @@ dotenv.config();
 const testApiKey = process.env.TEST_API_KEY;
 const { fetch } = fetchPonyfill({ Promise });
 
-describe.only('ConstructorIO - Search', () => {
+describe('ConstructorIO - Search', () => {
   const clientVersion = 'cio-mocha';
   let fetchSpy;
 


### PR DESCRIPTION
Pass in spied fetch object to allow inspection of request URL parameters.

This pattern will be very useful within the tracking branch to ensure all expected request parameters are present.

Why not mock the requests rather than continue to send them?
> Running the entire test suite only takes ~16 seconds currently. It seems like a solid idea to continue hitting the endpoints directly to ensure things are running as we expect. If the test run time increases substantially in the future, we should investigate mocking.

All tests pass (81/81).
Coverage: 95.96%.