### PR TITLE
Feature/recommendation ~placements~ pods

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ constructorio.recommendations.getRecommendations('pod-id', { parameters }).then(
 
 | Parameter | Type | Description |
 | --- | --- | --- |
-| `results` | number | Number of results to retrieve |
+| `numResults` | number | Number of results to retrieve |
 | `itemIds` | string or array | Item ID(s) to retrieve recommendations for |
 | `section` | string | Section to display results from |
 

--- a/README.md
+++ b/README.md
@@ -88,38 +88,11 @@ constructorio.autocomplete.getResults('dogs', {
 
 ### Recommendations
 
-The recommendations module can be used to retrieve item recommendation results. Responses will be delivered via a Promise. The `parameters` object is optional. Item id's may be of type string or array.
+The recommendations module can be used to retrieve item recommendation results for a supplied pod identifier. Responses will be delivered via a Promise. The `parameters` object is optional. Item id's may be of type string or array.
 
-#### Retrieve alternative item recommendations
+#### Retrieve recommendations
 ```javascript
-constructorio.recommendations.getAlternativeItems('item-id', { parameters }).then(function(response) {
-  console.log(response);
-}).catch(function(err) {
-  console.error(err);
-});
-```
-
-#### Retrieve complementary item recommendations
-```javascript
-constructorio.recommendations.getComplementaryItems('item-id', { parameters }).then(function(response) {
-  console.log(response);
-}).catch(function(err) {
-  console.error(err);
-});
-```
-
-#### Retrieve recently viewed item recommendations
-```javascript
-constructorio.recommendations.getRecentlyViewedItems({ parameters }).then(function(response) {
-  console.log(response);
-}).catch(function(err) {
-  console.error(err);
-});
-```
-
-#### Retrieve user featured item recommendations
-```javascript
-constructorio.recommendations.getUserFeaturedItems({ parameters }).then(function(response) {
+constructorio.recommendations.getRecommendations('pod-id', { parameters }).then(function(response) {
   console.log(response);
 }).catch(function(err) {
   console.error(err);
@@ -129,6 +102,8 @@ constructorio.recommendations.getUserFeaturedItems({ parameters }).then(function
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `results` | number | Number of results to retrieve |
+| `itemIds` | string or array | Item ID(s) to retrieve recommendations for |
+| `section` | string | Section to display results from |
 
 ### Tracker
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ constructorio.autocomplete.getResults('dogs', {
 
 ### Recommendations
 
-The recommendations module can be used to retrieve item recommendation results for a supplied pod identifier. Responses will be delivered via a Promise. The `parameters` object is optional. Item id's may be of type string or array.
+The recommendations module can be used to retrieve recommendations for a given pod. Responses will be delivered via a Promise. The `parameters` object is optional.
 
 #### Retrieve recommendations
 ```javascript

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -35,7 +35,7 @@ describe('ConstructorIO - Recommendations', () => {
   });
 
   describe('getRecommendations', () => {
-    const placement = 'item_page_1';
+    const pod = 'item_page_1';
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
@@ -45,7 +45,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, { itemIds: itemId }).then((res) => {
+      recommendations.getRecommendations(pod, { itemIds: itemId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -69,7 +69,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
+      recommendations.getRecommendations(pod, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -90,7 +90,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
+      recommendations.getRecommendations(pod, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -109,7 +109,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
+      recommendations.getRecommendations(pod, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -127,7 +127,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, {
+      recommendations.getRecommendations(pod, {
         itemIds,
         results,
       }).then((res) => {
@@ -149,7 +149,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getRecommendations(placement, {
+      recommendations.getRecommendations(pod, {
         itemIds,
         section,
       }).then((res) => {
@@ -167,7 +167,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should return a response with valid itemIds, with a result_id appended to each result', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
+      recommendations.getRecommendations(pod, { itemIds }).then((res) => {
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
@@ -179,7 +179,7 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid placements parameter is provided', () => {
+    it('Should be rejected when invalid pod parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getRecommendations([], {
@@ -187,7 +187,7 @@ describe('ConstructorIO - Recommendations', () => {
       })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when no placements parameter is provided', () => {
+    it('Should be rejected when no pod parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getRecommendations(null, {
@@ -198,7 +198,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getRecommendations(placement, {
+      return expect(recommendations.getRecommendations(pod, {
         itemIds,
         results: 'abc',
       })).to.eventually.be.rejected;
@@ -207,7 +207,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should be rejected when invalid section parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getRecommendations(placement, {
+      return expect(recommendations.getRecommendations(pod, {
         itemIds,
         section: 'Nonsense',
       })).to.eventually.be.rejected;
@@ -216,7 +216,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getRecommendations(placement, {
+      return expect(recommendations.getRecommendations(pod, {
         itemIds,
       })).to.eventually.be.rejected;
     });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -34,7 +34,8 @@ describe('ConstructorIO - Recommendations', () => {
     fetchSpy = null;
   });
 
-  describe('getAlternativeItems', () => {
+  describe('getRecommendations', () => {
+    const placement = 'item_page_1';
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
@@ -44,7 +45,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getAlternativeItems(itemId).then((res) => {
+      recommendations.getRecommendations(placement, { itemIds: itemId }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -68,7 +69,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getAlternativeItems(itemIds).then((res) => {
+      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -89,7 +90,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getAlternativeItems(itemId).then((res) => {
+      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -108,7 +109,7 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getAlternativeItems(itemId).then((res) => {
+      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -126,7 +127,10 @@ describe('ConstructorIO - Recommendations', () => {
         fetch: fetchSpy,
       });
 
-      recommendations.getAlternativeItems(itemId, { results }).then((res) => {
+      recommendations.getRecommendations(placement, {
+        itemIds,
+        results,
+      }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
@@ -134,6 +138,28 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.num_results).to.equal(results);
         expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
+        done();
+      });
+    });
+
+    it('Should return a response with valid itemIds, and section', (done) => {
+      const section = 'Products';
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendations(placement, {
+        itemIds,
+        section,
+      }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(res.request.section).to.equal(section);
+        expect(requestedUrlParams).to.have.property('section').to.equal(section);
         done();
       });
     });
@@ -141,7 +167,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should return a response with valid itemIds, with a result_id appended to each result', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      recommendations.getAlternativeItems(itemId).then((res) => {
+      recommendations.getRecommendations(placement, { itemIds }).then((res) => {
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
@@ -153,402 +179,46 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should be rejected when invalid itemIds are provided', () => {
+    it('Should be rejected when invalid placements parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems({})).to.eventually.be.rejected;
+      return expect(recommendations.getRecommendations([], {
+        itemIds,
+      })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when no itemIds are provided', () => {
+    it('Should be rejected when no placements parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems()).to.eventually.be.rejected;
+      return expect(recommendations.getRecommendations(null, {
+        itemIds,
+      })).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid results parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
-      return expect(recommendations.getAlternativeItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
+      return expect(recommendations.getRecommendations(placement, {
+        itemIds,
+        results: 'abc',
+      })).to.eventually.be.rejected;
+    });
+
+    it('Should be rejected when invalid section parameter is provided', () => {
+      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+
+      return expect(recommendations.getRecommendations(placement, {
+        itemIds,
+        section: 'Nonsense',
+      })).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid apiKey is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
 
-      return expect(recommendations.getAlternativeItems(itemId)).to.eventually.be.rejected;
-    });
-  });
-
-  describe('getComplementaryItems', () => {
-    const itemId = 'power_drill';
-    const itemIds = [itemId, 'drill'];
-
-    it('Should return a response with valid itemIds (singular)', (done) => {
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getComplementaryItems(itemId).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.item_id).to.equal(itemId);
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(fetchSpy).to.have.been.called;
-        expect(requestedUrlParams).to.have.property('key');
-        expect(requestedUrlParams).to.have.property('i');
-        expect(requestedUrlParams).to.have.property('s');
-        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
-        expect(requestedUrlParams).to.have.property('item_id').to.equal(itemId);
-        done();
-      });
-    });
-
-    it('Should return a response with valid itemIds (multiple)', (done) => {
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getComplementaryItems(itemIds).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.item_id).to.deep.equal(itemIds);
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
-        done();
-      });
-    });
-
-    it('Should return a response with valid itemIds, and segments', (done) => {
-      const segments = 'segments';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        segments,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getComplementaryItems(itemId).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
-        done();
-      });
-    });
-
-    it('Should return a response with valid itemIds, and user id', (done) => {
-      const userId = 'user-id';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getComplementaryItems(itemId).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('ui').to.equal(userId);
-        done();
-      });
-    });
-
-    it('Should return a response with valid itemIds, and results', (done) => {
-      const results = 2;
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getComplementaryItems(itemId, { results }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.num_results).to.equal(results);
-        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
-        done();
-      });
-    });
-
-    it('Should return a response with valid itemIds, with a result_id appended to each result', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      recommendations.getComplementaryItems(itemId).then((res) => {
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        res.response.results.forEach((item) => {
-          expect(item).to.have.property('result_id').to.be.a('string').to.equal(res.result_id);
-        });
-        done();
-      });
-    });
-
-    it('Should be rejected when invalid itemIds are provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      return expect(recommendations.getComplementaryItems({})).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when no itemIds are provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      return expect(recommendations.getComplementaryItems()).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when invalid results parameter is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      return expect(recommendations.getComplementaryItems(itemId, { results: 'abc' })).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when invalid apiKey is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
-
-      return expect(recommendations.getComplementaryItems(itemId)).to.eventually.be.rejected;
-    });
-  });
-
-  describe('getRecentlyViewedItems', () => {
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
-    it('Should return a response', (done) => {
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getRecentlyViewedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(requestedUrlParams).to.have.property('key');
-        expect(requestedUrlParams).to.have.property('i');
-        expect(requestedUrlParams).to.have.property('s');
-        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
-        done();
-      });
-    });
-
-    it('Should return a response with valid segments', (done) => {
-      const segments = 'segments';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        segments,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getRecentlyViewedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
-        done();
-      });
-    });
-
-    it('Should return a response with valid user id', (done) => {
-      const userId = 'user-id';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getRecentlyViewedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('ui').to.equal(userId);
-        done();
-      });
-    });
-
-    it('Should return a response with valid results', (done) => {
-      const results = 2;
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getRecentlyViewedItems({ results }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.num_results).to.equal(results);
-        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
-        done();
-      });
-    });
-
-    it('Should return a response with a result_id appended to each result', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      recommendations.getRecentlyViewedItems().then((res) => {
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        res.response.results.forEach((item) => {
-          expect(item).to.have.property('result_id').to.be.a('string').to.equal(res.result_id);
-        });
-        done();
-      });
-    });
-
-    it('Should be rejected when invalid results parameter is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      return expect(recommendations.getRecentlyViewedItems({ results: 'abc' })).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when invalid apiKey is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
-
-      return expect(recommendations.getRecentlyViewedItems()).to.eventually.be.rejected;
-    });
-  });
-
-  describe('getUserFeaturedItems', () => {
-    beforeEach(() => {
-      global.CLIENT_VERSION = 'cio-mocha';
-    });
-
-    afterEach(() => {
-      delete global.CLIENT_VERSION;
-    });
-
-    it('Should return a response', (done) => {
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getUserFeaturedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        expect(requestedUrlParams).to.have.property('key');
-        expect(requestedUrlParams).to.have.property('i');
-        expect(requestedUrlParams).to.have.property('s');
-        expect(requestedUrlParams).to.have.property('c').to.equal(clientVersion);
-        done();
-      });
-    });
-
-    it('Should return a response with valid segments', (done) => {
-      const segments = 'segments';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        segments,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getUserFeaturedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('us').to.equal(segments);
-        done();
-      });
-    });
-
-    it('Should return a response with valid user id', (done) => {
-      const userId = 'user-id';
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        userId,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getUserFeaturedItems().then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(requestedUrlParams).to.have.property('ui').to.equal(userId);
-        done();
-      });
-    });
-
-    it('Should return a response with valid results', (done) => {
-      const results = 2;
-      const { recommendations } = new ConstructorIO({
-        apiKey: testApiKey,
-        fetch: fetchSpy,
-      });
-
-      recommendations.getUserFeaturedItems({ results }).then((res) => {
-        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
-
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.num_results).to.equal(results);
-        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
-        done();
-      });
-    });
-
-    it('Should return a response with a result_id appended to each result', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      recommendations.getUserFeaturedItems().then((res) => {
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        res.response.results.forEach((item) => {
-          expect(item).to.have.property('result_id').to.be.a('string').to.equal(res.result_id);
-        });
-        done();
-      });
-    });
-
-    it('Should be rejected when invalid results parameter is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
-
-      return expect(recommendations.getUserFeaturedItems({ results: 'abc' })).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when invalid apiKey is provided', () => {
-      const { recommendations } = new ConstructorIO({ apiKey: 'fyzs7tfF8L161VoAXQ8u' });
-
-      return expect(recommendations.getUserFeaturedItems()).to.eventually.be.rejected;
+      return expect(recommendations.getRecommendations(placement, {
+        itemIds,
+      })).to.eventually.be.rejected;
     });
   });
 });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -55,6 +55,7 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res.response).to.have.property('results').to.be.an('array');
         expect(res.response).to.have.property('pod');
         expect(res.response.pod).to.have.property('id').to.equal(pod);
+        expect(res.response.pod).to.have.property('display_name');
         expect(fetchSpy).to.have.been.called;
         expect(requestedUrlParams).to.have.property('key');
         expect(requestedUrlParams).to.have.property('i');
@@ -81,6 +82,7 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res.response).to.have.property('results').to.be.an('array');
         expect(res.response).to.have.property('pod');
         expect(res.response.pod).to.have.property('id').to.equal(pod);
+        expect(res.response.pod).to.have.property('display_name');
         expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
         done();
       });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -53,6 +53,8 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.equal(itemId);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response).to.have.property('pod');
+        expect(res.response.pod).to.have.property('id').to.equal(pod);
         expect(fetchSpy).to.have.been.called;
         expect(requestedUrlParams).to.have.property('key');
         expect(requestedUrlParams).to.have.property('i');
@@ -77,6 +79,8 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res).to.have.property('result_id').to.be.an('string');
         expect(res.request.item_id).to.deep.equal(itemIds);
         expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response).to.have.property('pod');
+        expect(res.response.pod).to.have.property('id').to.equal(pod);
         expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
         done();
       });

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -120,8 +120,8 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
-    it('Should return a response with valid itemIds, and results', (done) => {
-      const results = 2;
+    it('Should return a response with valid itemIds, and numResults', (done) => {
+      const numResults = 2;
       const { recommendations } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -129,15 +129,15 @@ describe('ConstructorIO - Recommendations', () => {
 
       recommendations.getRecommendations(pod, {
         itemIds,
-        results,
+        numResults,
       }).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('response').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.request.num_results).to.equal(results);
-        expect(requestedUrlParams).to.have.property('num_results').to.equal(results.toString());
+        expect(res.request.num_results).to.equal(numResults);
+        expect(requestedUrlParams).to.have.property('num_results').to.equal(numResults.toString());
         done();
       });
     });
@@ -195,12 +195,12 @@ describe('ConstructorIO - Recommendations', () => {
       })).to.eventually.be.rejected;
     });
 
-    it('Should be rejected when invalid results parameter is provided', () => {
+    it('Should be rejected when invalid numResults parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(recommendations.getRecommendations(pod, {
         itemIds,
-        results: 'abc',
+        numResults: 'abc',
       })).to.eventually.be.rejected;
     });
 

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -5,7 +5,7 @@ const Promise = require('es6-promise');
 const { throwHttpErrorFromResponse, cleanParams } = require('../utils/helpers');
 
 // Create URL from supplied parameters
-function createRecommendationsUrl(placement, parameters, options) {
+function createRecommendationsUrl(pod, parameters, options) {
   const { apiKey, version, serviceUrl, sessionId, userId, clientId, segments } = options;
   let queryParams = { c: version };
 
@@ -13,9 +13,9 @@ function createRecommendationsUrl(placement, parameters, options) {
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
-  // Validate placement is provided
-  if (!placement || typeof placement !== 'string') {
-    throw new Error('placement is a required parameter of type string');
+  // Validate pod is provided
+  if (!pod || typeof pod !== 'string') {
+    throw new Error('pod is a required parameter of type string');
   }
 
   // Pull user segments from options
@@ -51,11 +51,11 @@ function createRecommendationsUrl(placement, parameters, options) {
 
   const queryString = qs.stringify(queryParams, { indices: false });
 
-  return `${serviceUrl}/recommendations/v1/placements/${placement}?${queryString}`;
+  return `${serviceUrl}/recommendations/v1/pods/${pod}?${queryString}`;
 }
 
 /**
- * Interface to recommendations related API calls.
+ * Interface to recommendations related API calls
  *
  * @module recommendations
  * @inner
@@ -67,10 +67,10 @@ class Recommendations {
   }
 
   /**
-   * Get recommendations for supplied placement identifier
+   * Get recommendations for supplied pod identifier
    *
    * @function getRecommendations
-   * @param {string} placement - Placement identifier
+   * @param {string} pod - Pod identifier
    * @param {object} [parameters] - Additional parameters to refine results
    * @param {string|array} [parameters.itemIds] - Item ID(s) to retrieve recommendations for
    * @param {number} [parameters.results] - The number of results to return
@@ -78,14 +78,14 @@ class Recommendations {
    * @returns {Promise}
    * @see https://docs.constructor.io
    */
-  getRecommendations(placement, parameters) {
+  getRecommendations(pod, parameters) {
     let requestUrl;
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     parameters = parameters || {};
 
     try {
-      requestUrl = createRecommendationsUrl(placement, parameters, this.options);
+      requestUrl = createRecommendationsUrl(pod, parameters, this.options);
     } catch (e) {
       return Promise.reject(e);
     }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -13,6 +13,11 @@ function createRecommendationsUrl(placement, parameters, options) {
   queryParams.i = clientId;
   queryParams.s = sessionId;
 
+  // Validate placement is provided
+  if (!placement || typeof placement !== 'string') {
+    throw new Error('placement is a required parameter of type string');
+  }
+
   // Pull user segments from options
   if (segments && segments.length) {
     queryParams.us = segments;
@@ -46,7 +51,7 @@ function createRecommendationsUrl(placement, parameters, options) {
 
   const queryString = qs.stringify(queryParams, { indices: false });
 
-  return `${serviceUrl}recommendations/v1/placements/${placement}/?${queryString}`;
+  return `${serviceUrl}/recommendations/v1/placements/${placement}?${queryString}`;
 }
 
 /**
@@ -84,6 +89,7 @@ class Recommendations {
     } catch (e) {
       return Promise.reject(e);
     }
+
 
     return fetch(requestUrl)
       .then((response) => {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -29,11 +29,11 @@ function createRecommendationsUrl(pod, parameters, options) {
   }
 
   if (parameters) {
-    const { results, itemIds, section } = parameters;
+    const { numResults, itemIds, section } = parameters;
 
-    // Pull results number from parameters
-    if (results) {
-      queryParams.num_results = results;
+    // Pull num results number from parameters
+    if (numResults) {
+      queryParams.num_results = numResults;
     }
 
     // Pull item ids from parameters
@@ -73,7 +73,7 @@ class Recommendations {
    * @param {string} pod - Pod identifier
    * @param {object} [parameters] - Additional parameters to refine results
    * @param {string|array} [parameters.itemIds] - Item ID(s) to retrieve recommendations for
-   * @param {number} [parameters.results] - The number of results to return
+   * @param {number} [parameters.numResults] - The number of results to return
    * @param {string} [parameters.section] - The section to return results from
    * @returns {Promise}
    * @see https://docs.constructor.io


### PR DESCRIPTION
- Recommendations endpoint changes to utilize pod identifier in favor of declaring specific method.
- `results` becomes `numResults`.

*Do not merge* - blocked until backend `/pods/` endpoint has been deployed.