### PR TITLE
Add recommendations tracking methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,37 @@ constructorio.tracker.trackPurchase({
 | `revenue` | string | ? |
 | `section` | string | ? |
 
+#### Send recommendation view event
+```javascript
+constructorio.tracker.trackRecommendationView({
+    parameters
+});
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `result_id` | string | ? |
+| `section` | string | ? |
+| `pod_id` | string | ? |
+| `num_results_viewed` | number | ? |
+
+#### Send recommendation click through event
+```javascript
+constructorio.tracker.trackRecommendationClickThrough({
+    parameters
+});
+```
+
+| Parameter | Type | Description |
+| --- | --- | --- |
+| `result_id` | string | ? |
+| `section` | string | ? |
+| `pod_id` | string | ? |
+| `item_id` | string | ? |
+| `variation_id` | string | ? |
+| `item_position` | string | ? |
+| `strategy_id` | string | ? |
+
 ## Development / npm commands
 
 ```bash

--- a/spec/mocha.helpers.js
+++ b/spec/mocha.helpers.js
@@ -63,6 +63,19 @@ const extractUrlParamsFromFetch = (fetch) => {
   return null;
 };
 
+// Extract body parameters as object from request
+const extractBodyParamsFromFetch = (fetch) => {
+  const lastCallArguments = fetch && fetch.args && fetch.args[fetch.args.length - 1];
+  const requestData = lastCallArguments[1];
+  const { body } = requestData;
+
+  if (body) {
+    return body;
+  }
+
+  return null;
+};
+
 module.exports = {
   setupDOM,
   teardownDOM,
@@ -70,4 +83,5 @@ module.exports = {
   triggerUnload,
   clearStorage,
   extractUrlParamsFromFetch,
+  extractBodyParamsFromFetch,
 };

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -525,7 +525,7 @@ describe('ConstructorIO - Tracker', () => {
         fetch: fetchSpy,
       });
 
-      expect(tracker.trackConversion(term, parameters)).to.equal(true);
+      expect(tracker.trackConversion(term, {})).to.equal(true);
 
       const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -615,10 +615,7 @@ describe('ConstructorIO - Tracker', () => {
         fetch: fetchSpy,
       });
 
-      expect(tracker.trackPurchase({
-        customer_ids: parameters.customer_ids,
-        revenue: parameters.revenue,
-      })).to.equal(true);
+      expect(tracker.trackPurchase({})).to.equal(true);
 
       const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
@@ -755,6 +752,98 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(tracker.trackRecommendationView()).to.be.an('error');
+    });
+  });
+
+  describe('trackRecommendationClickThrough', () => {
+    const parameters = {
+      result_id: 'result-id',
+      section: 'Products',
+      pod_id: 'pod-id',
+      item_id: 'item-id',
+      variation_id: 'variation-id',
+      item_position: 5,
+      strategy_id: 'strategy-id',
+    };
+
+    it('Should respond with a valid response when parameters are provided', () => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationClickThrough(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(fetchSpy).to.have.been.called;
+      expect(requestedBodyParams).to.have.property('key');
+      expect(requestedBodyParams).to.have.property('i');
+      expect(requestedBodyParams).to.have.property('s');
+      expect(requestedBodyParams).to.have.property('c').to.equal(clientVersion);
+      expect(requestedBodyParams).to.have.property('_dt');
+      expect(requestedBodyParams).to.have.property('result_id').to.deep.equal(parameters.result_id);
+      expect(requestedBodyParams).to.have.property('section').to.equal(parameters.section);
+      expect(requestedBodyParams).to.have.property('pod_id').to.equal(parameters.pod_id);
+      expect(requestedBodyParams).to.have.property('item_id').to.equal(parameters.item_id);
+      expect(requestedBodyParams).to.have.property('variation_id').to.equal(parameters.variation_id);
+      expect(requestedBodyParams).to.have.property('position').to.equal(parameters.item_position);
+      expect(requestedBodyParams).to.have.property('strategy_id').to.equal(parameters.strategy_id);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when parameters are provided', () => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationClickThrough({})).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('section').to.equal('Products');
+    });
+
+    it('Should respond with a valid response when parameters and segments are provided', () => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationClickThrough(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('us').to.deep.equal(segments);
+    });
+
+    it('Should respond with a valid response when parameters and user id are provided', () => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationClickThrough(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('ui').to.equal(userId);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationClickThrough([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationClickThrough()).to.be.an('error');
     });
   });
 });

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -615,14 +615,17 @@ describe('ConstructorIO - Tracker', () => {
         fetch: fetchSpy,
       });
 
-      expect(tracker.trackPurchase(parameters)).to.equal(true);
+      expect(tracker.trackPurchase({
+        customer_ids: parameters.customer_ids,
+        revenue: parameters.revenue,
+      })).to.equal(true);
 
       const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
 
       expect(requestedUrlParams).to.have.property('section').to.equal('Products');
     });
 
-    it('Should respond with a valid response parameters and segments are provided', () => {
+    it('Should respond with a valid response when parameters and segments are provided', () => {
       const segments = ['foo', 'bar'];
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
@@ -662,6 +665,96 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(tracker.trackPurchase()).to.be.an('error');
+    });
+  });
+
+  describe('trackRecommendationView', () => {
+    const parameters = {
+      result_id: 'result-id',
+      section: 'Products',
+      pod_id: 'pod-id',
+      num_results_viewed: 5,
+    };
+
+    it('Should respond with a valid response when parameters are provided', () => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationView(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(fetchSpy).to.have.been.called;
+      expect(requestedBodyParams).to.have.property('key');
+      expect(requestedBodyParams).to.have.property('i');
+      expect(requestedBodyParams).to.have.property('s');
+      expect(requestedBodyParams).to.have.property('c').to.equal(clientVersion);
+      expect(requestedBodyParams).to.have.property('_dt');
+      expect(requestedBodyParams).to.have.property('result_id').to.deep.equal(parameters.result_id);
+      expect(requestedBodyParams).to.have.property('section').to.equal(parameters.section);
+      expect(requestedBodyParams).to.have.property('pod_id').to.equal(parameters.pod_id);
+      expect(requestedBodyParams).to.have.property('num_results_viewed').to.equal(parameters.num_results_viewed);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when parameters are provided', () => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationView({
+        result_id: parameters.result_id,
+        pod_id: parameters.pod_id,
+        num_results_viewed: parameters.num_results_viewed,
+      })).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('section').to.equal('Products');
+    });
+
+    it('Should respond with a valid response when parameters and segments are provided', () => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationView(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('us').to.deep.equal(segments);
+    });
+
+    it('Should respond with a valid response when parameters and user id are provided', () => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackRecommendationView(parameters)).to.equal(true);
+
+      const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+      expect(requestedBodyParams).to.have.property('ui').to.equal(userId);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationView([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackRecommendationView()).to.be.an('error');
     });
   });
 });

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -45,6 +45,18 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       expect(store.local.get(storageKey)).to.be.an('array').length(3);
     });
 
+    it('Should add requests to the queue and persist on unload event - POST with body', () => {
+      const requests = new RequestQueue();
+
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'session_start' });
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'focus' });
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'magic_number_three' });
+
+      expect(requests.get()).to.be.an('array').length(3);
+      helpers.triggerUnload();
+      expect(store.local.get(storageKey)).to.be.an('array').length(3);
+    });
+
     it('Should not add requests to the queue if the user has a bot-like useragent', () => {
       const requests = new RequestQueue();
 
@@ -94,6 +106,23 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
       requests.queue('https://ac.cnstrc.com/behavior?action=focus');
       requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+
+      expect(requests.get()).to.be.an('array').length(3);
+      helpers.triggerResize();
+      requests.send();
+
+      setTimeout(() => {
+        expect(requests.get()).to.be.an('array').length(0);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should send all tracking requests if queue is populated and user is human - POST with body', (done) => {
+      const requests = new RequestQueue();
+
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'session_start' });
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'focus' });
+      requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'magic_number_three' });
 
       expect(requests.get()).to.be.an('array').length(3);
       helpers.triggerResize();

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -139,7 +139,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       }, waitInterval);
     });
 
-    it('Should send all tracking requests if requests exist in storage and user is human', (done) => {
+    it('Should send all tracking requests if requests exist in storage and user is human - backwards compatibility', (done) => {
       store.local.set(storageKey, [
         'https://ac.cnstrc.com/behavior?action=session_start',
         'https://ac.cnstrc.com/behavior?action=focus',
@@ -158,11 +158,48 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       }, waitInterval);
     });
 
+    it('Should send all tracking requests if requests exist in storage and user is human', (done) => {
+      store.local.set(storageKey, [
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=session_start',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=focus',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+          method: 'GET',
+        },
+      ]);
+
+      const requests = new RequestQueue();
+
+      expect(requests.get()).to.be.an('array').length(3);
+      helpers.triggerResize();
+      requests.send();
+
+      setTimeout(() => {
+        expect(requests.get()).to.be.an('array').length(0);
+        done();
+      }, waitInterval);
+    });
+
     it('Should not send tracking requests if requests exist in storage and user is not human', (done) => {
       store.local.set(storageKey, [
-        'https://ac.cnstrc.com/behavior?action=session_start',
-        'https://ac.cnstrc.com/behavior?action=focus',
-        'https://ac.cnstrc.com/behavior?action=magic_number_three',
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=session_start',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=focus',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+          method: 'GET',
+        },
       ]);
 
       const requests = new RequestQueue();
@@ -178,9 +215,18 @@ describe('ConstructorIO - Utils - Request Queue', () => {
 
     it('Should not send tracking requests if requests exist in storage and user is human and page is unloading', (done) => {
       store.local.set(storageKey, [
-        'https://ac.cnstrc.com/behavior?action=session_start',
-        'https://ac.cnstrc.com/behavior?action=focus',
-        'https://ac.cnstrc.com/behavior?action=magic_number_three',
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=session_start',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=focus',
+          method: 'GET',
+        },
+        {
+          url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+          method: 'GET',
+        },
       ]);
 
       const requests = new RequestQueue();

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -4,7 +4,7 @@ const helpers = require('../utils/helpers');
 const RequestQueue = require('../utils/request-queue');
 
 // Append common parameters to supplied parameters object
-function applyParameters(parameters, options, returnType = 'string') {
+function applyParams(parameters, options) {
   const { apiKey, version, sessionId, clientId, userId, segments } = options;
   let aggregateParams = Object.assign(parameters);
 
@@ -35,13 +35,12 @@ function applyParameters(parameters, options, returnType = 'string') {
   aggregateParams._dt = Date.now();
   aggregateParams = helpers.cleanParams(aggregateParams);
 
-  // Return as object to be used with GET requests
-  if (returnType === 'string') {
-    return qs.stringify(aggregateParams, { indices: false });
-  }
-
-  // Return as query string to be used with POST requests
   return aggregateParams;
+}
+
+// Append common parameters to supplied parameters object and return as string
+function applyParamsAsString(parameters, options) {
+  return qs.stringify(applyParams(parameters, options), { indices: false });
 }
 
 /**
@@ -67,7 +66,7 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'session_start' };
 
-    this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+    this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
     this.requests.send();
 
     return true;
@@ -83,7 +82,7 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'focus' };
 
-    this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+    this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
     this.requests.send();
 
     return true;
@@ -143,7 +142,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -195,7 +194,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -238,7 +237,7 @@ class Tracker {
           queryParams.customer_ids = customer_ids.join(',');
         }
 
-        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -286,7 +285,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -345,7 +344,7 @@ class Tracker {
         queryParams.section = 'Products';
       }
 
-      this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+      this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
       this.requests.send();
 
       return true;
@@ -388,7 +387,7 @@ class Tracker {
         queryParams.section = 'Products';
       }
 
-      this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
+      this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);
       this.requests.send();
 
       return true;
@@ -436,7 +435,7 @@ class Tracker {
         bodyParams.num_results_viewed = num_results_viewed;
       }
 
-      this.requests.queue(url, 'POST', applyParameters(bodyParams, this.options, 'object'));
+      this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));
       this.requests.send();
 
       return true;
@@ -507,7 +506,7 @@ class Tracker {
         bodyParams.strategy_id = strategy_id;
       }
 
-      this.requests.queue(url, 'POST', applyParameters(bodyParams, this.options, 'object'));
+      this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));
       this.requests.send();
 
       return true;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -446,6 +446,77 @@ class Tracker {
 
     return new Error('parameters are required of type object');
   }
+
+  /**
+   * Send recommendation click through event to API
+   *
+   * @function trackRecommendationClickThrough
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.result_id - Result identifier
+   * @param {string} parameters.section - Results section (defaults to "Products")
+   * @param {string} parameters.pod_id - Pod identifier
+   * @param {string} parameters.item_id - ID of clicked item
+   * @param {string} parameters.variation_id - Variation ID of clicked item
+   * @param {number} parameters.item_position - Position of clicked item
+   * @param {string} parameters.strategy_id - Strategy identifier
+   * @returns {(true|Error)}
+   */
+  trackRecommendationClickThrough(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const url = `${this.options.serviceUrl}/v2/behavior/recommendation_result_click_through`;
+      const bodyParams = {};
+
+      const {
+        result_id,
+        section,
+        pod_id,
+        item_id,
+        variation_id,
+        item_position,
+        strategy_id,
+      } = parameters;
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (pod_id) {
+        bodyParams.pod_id = pod_id;
+      }
+
+      if (item_id) {
+        bodyParams.item_id = item_id;
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (item_position) {
+        bodyParams.position = item_position;
+      }
+
+      if (strategy_id) {
+        bodyParams.strategy_id = strategy_id;
+      }
+
+      this.requests.queue(url, 'POST', applyParameters(bodyParams, this.options, 'object'));
+      this.requests.send();
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
 }
 
 module.exports = Tracker;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -392,6 +392,54 @@ class Tracker {
 
     return new Error('parameters are required of type object');
   }
+
+  /**
+   * Send recommendation view event to API
+   *
+   * @function trackRecommendationView
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} parameters.result_id - Result identifier
+   * @param {string} parameters.section - Results section (defaults to "Products")
+   * @param {string} parameters.pod_id - Pod identifier
+   * @param {number} parameters.num_results_viewed - Number of results viewed
+   * @returns {(true|Error)}
+   */
+  trackRecommendationView(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const url = `${this.options.serviceUrl}/v2/behavior/recommendation_result_view`;
+      const bodyParams = {};
+
+      const { result_id, section, pod_id, num_results_viewed } = parameters;
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (pod_id) {
+        bodyParams.pod_id = pod_id;
+      }
+
+      if (num_results_viewed) {
+        bodyParams.num_results_viewed = num_results_viewed;
+      }
+
+      this.requests.queue(url, 'POST', bodyParams);
+      this.requests.send();
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
 }
 
 module.exports = Tracker;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -4,38 +4,44 @@ const helpers = require('../utils/helpers');
 const RequestQueue = require('../utils/request-queue');
 
 // Append common parameters to supplied parameters object
-function createQueryString(parameters, options) {
+function applyParameters(parameters, options, returnType = 'string') {
   const { apiKey, version, sessionId, clientId, userId, segments } = options;
-  let queryParams = Object.assign(parameters);
+  let aggregateParams = Object.assign(parameters);
 
   if (version) {
-    queryParams.c = version;
+    aggregateParams.c = version;
   }
 
   if (clientId) {
-    queryParams.i = clientId;
+    aggregateParams.i = clientId;
   }
 
   if (sessionId) {
-    queryParams.s = sessionId;
+    aggregateParams.s = sessionId;
   }
 
   if (userId) {
-    queryParams.ui = userId;
+    aggregateParams.ui = userId;
   }
 
   if (segments && segments.length) {
-    queryParams.us = segments;
+    aggregateParams.us = segments;
   }
 
   if (apiKey) {
-    queryParams.key = apiKey;
+    aggregateParams.key = apiKey;
   }
 
-  queryParams._dt = Date.now();
-  queryParams = helpers.cleanParams(queryParams);
+  aggregateParams._dt = Date.now();
+  aggregateParams = helpers.cleanParams(aggregateParams);
 
-  return qs.stringify(queryParams, { indices: false });
+  // Return as object to be used with GET requests
+  if (returnType === 'string') {
+    return qs.stringify(aggregateParams, { indices: false });
+  }
+
+  // Return as query string to be used with POST requests
+  return aggregateParams;
 }
 
 /**
@@ -61,7 +67,7 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'session_start' };
 
-    this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+    this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
     this.requests.send();
 
     return true;
@@ -77,7 +83,7 @@ class Tracker {
     const url = `${this.options.serviceUrl}/behavior?`;
     const queryParams = { action: 'focus' };
 
-    this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+    this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
     this.requests.send();
 
     return true;
@@ -137,7 +143,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -189,7 +195,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -232,7 +238,7 @@ class Tracker {
           queryParams.customer_ids = customer_ids.join(',');
         }
 
-        this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -280,7 +286,7 @@ class Tracker {
           queryParams.result_id = result_id;
         }
 
-        this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+        this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
         this.requests.send();
 
         return true;
@@ -339,7 +345,7 @@ class Tracker {
         queryParams.section = 'Products';
       }
 
-      this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+      this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
       this.requests.send();
 
       return true;
@@ -382,7 +388,7 @@ class Tracker {
         queryParams.section = 'Products';
       }
 
-      this.requests.queue(`${url}${createQueryString(queryParams, this.options)}`);
+      this.requests.queue(`${url}${applyParameters(queryParams, this.options)}`);
       this.requests.send();
 
       return true;
@@ -430,7 +436,7 @@ class Tracker {
         bodyParams.num_results_viewed = num_results_viewed;
       }
 
-      this.requests.queue(url, 'POST', bodyParams);
+      this.requests.queue(url, 'POST', applyParameters(bodyParams, this.options, 'object'));
       this.requests.send();
 
       return true;


### PR DESCRIPTION
- Support POST requests to new v2 endpoints (parameters are contained within body, not URL)
- Request queue items are now objects instead of strings to allow storing of method and body parameters.
- "Legacy" request queue items (strings) are still supported due to backwards compatibility shim.
- Document new endpoints in readme.
- Tests for new endpoints.

Coverage:
98.66% Statements 588/596
86.32% Branches 303/351
98.39% Functions 61/62
98.4% Lines 493/501

Tests:
146/146 passing