### PR TITLE
Browse tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,27 @@ constructorio.tracker.trackRecommendationClickThrough({
 | `item_position` | string | ? |
 | `strategy_id` | string | ? |
 
+#### Send browse result click event
+```javascript
+constructorio.tracker.trackBrowseResultClick({
+    parameters
+});
+```
+
+| Parameter | Type |
+| --- | --- |
+| `item_id` | string |
+| `variation_id` | string |
+| `section` | string |
+| `result_id` | string |
+| `result_count` | integer |
+| `result_page` | integer |
+| `result_position_on_page` | integer |
+| `num_results_per_page` | integer |
+| `selected_filters` | string or array |
+| `filter_name` | string |
+| `filter_value` | string |
+
 #### Receive status of tracking requests
 The status of tracking requests can be observed through emitted events. `messageType` must be either "success" or "error", and the `callback` parameter must be a function that will be passed the message data as the first and only argument.
 ```javascript

--- a/README.md
+++ b/README.md
@@ -236,6 +236,25 @@ constructorio.tracker.trackRecommendationClickThrough({
 | `item_position` | string | ? |
 | `strategy_id` | string | ? |
 
+#### Send browse results load event
+```javascript
+constructorio.tracker.trackBrowseResultsLoaded({
+    parameters
+});
+```
+
+| Parameter | Type |
+| --- | --- |
+| `section` | string |
+| `result_id` | string |
+| `result_count` | integer |
+| `result_page` | integer |
+| `selected_filters` | string or array |
+| `sort_by` | string |
+| `sort_order` | string |
+| `filter_name` | string |
+| `filter_value` | string |
+
 #### Send browse result click event
 ```javascript
 constructorio.tracker.trackBrowseResultClick({

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "http-server": "^0.11.1",
     "jsdoc": "^3.6.3",
     "jsdom": "^15.1.1",
+    "lodash.clonedeep": "^4.5.0",
     "minami": "^1.2.3",
     "mocha": "^6.2.0",
     "mocha-jsdom": "^2.0.0",

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -951,6 +951,117 @@ describe('ConstructorIO - Tracker', () => {
     });
   });
 
+  describe('trackBrowseResultsLoaded', () => {
+    const parameters = {
+      section: 'Products',
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      selected_filters: ['foo', 'bar'],
+      sort_by: 'price',
+      sort_order: 'ascending',
+      filter_name: 'group_id',
+      filter_value: 'Clothing',
+    };
+
+    it('Should respond with a valid response when parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedBodyParams).to.have.property('key');
+        expect(requestedBodyParams).to.have.property('i');
+        expect(requestedBodyParams).to.have.property('s');
+        expect(requestedBodyParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestedBodyParams).to.have.property('_dt');
+        expect(requestedBodyParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestedBodyParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestedBodyParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestedBodyParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestedBodyParams).to.have.property('selected_filters').to.deep.equal(parameters.selected_filters);
+        expect(requestedBodyParams).to.have.property('sort_by').to.equal(parameters.sort_by);
+        expect(requestedBodyParams).to.have.property('sort_order').to.equal(parameters.sort_order);
+        expect(requestedBodyParams).to.have.property('filter_name').to.equal(parameters.filter_name);
+        expect(requestedBodyParams).to.have.property('filter_value').to.equal(parameters.filter_value);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(parameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackBrowseResultsLoaded(clonedParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('section').to.equal('Products');
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('us').to.deep.equal(segments);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when parameters and user id are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultsLoaded(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('ui').to.equal(userId);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultsLoaded([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultsLoaded()).to.be.an('error');
+    });
+  });
+
   describe('trackBrowseResultClick', () => {
     const parameters = {
       item_id: 'item-id',

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -7,6 +7,7 @@ const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
+const cloneDeep = require('lodash.clonedeep');
 const store = require('../../../src/utils/store');
 const ConstructorIO = require('../../../src/constructorio');
 const helpers = require('../../mocha.helpers');
@@ -947,6 +948,121 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(tracker.trackRecommendationClickThrough()).to.be.an('error');
+    });
+  });
+
+  describe('trackBrowseResultClick', () => {
+    const parameters = {
+      item_id: 'item-id',
+      variation_id: 'variation-id',
+      section: 'Products',
+      result_count: 5,
+      result_page: 1,
+      result_id: 'result-id',
+      result_position_on_page: 10,
+      num_results_per_page: 5,
+      selected_filters: ['foo', 'bar'],
+      filter_name: 'group_id',
+      filter_value: 'Clothing',
+    };
+
+    it('Should respond with a valid response when parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(fetchSpy).to.have.been.called;
+        expect(requestedBodyParams).to.have.property('key');
+        expect(requestedBodyParams).to.have.property('i');
+        expect(requestedBodyParams).to.have.property('s');
+        expect(requestedBodyParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestedBodyParams).to.have.property('_dt');
+        expect(requestedBodyParams).to.have.property('item_id').to.equal(parameters.item_id);
+        expect(requestedBodyParams).to.have.property('variation_id').to.deep.equal(parameters.variation_id);
+        expect(requestedBodyParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestedBodyParams).to.have.property('result_count').to.equal(parameters.result_count);
+        expect(requestedBodyParams).to.have.property('result_page').to.equal(parameters.result_page);
+        expect(requestedBodyParams).to.have.property('result_id').to.equal(parameters.result_id);
+        expect(requestedBodyParams).to.have.property('result_position_on_page').to.equal(parameters.result_position_on_page);
+        expect(requestedBodyParams).to.have.property('num_results_per_page').to.equal(parameters.num_results_per_page);
+        expect(requestedBodyParams).to.have.property('selected_filters').to.deep.equal(parameters.selected_filters);
+        expect(requestedBodyParams).to.have.property('filter_name').to.equal(parameters.filter_name);
+        expect(requestedBodyParams).to.have.property('filter_value').to.equal(parameters.filter_value);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response and section should be defaulted when parameters are provided', (done) => {
+      const clonedParameters = cloneDeep(parameters);
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      delete clonedParameters.section;
+
+      expect(tracker.trackBrowseResultClick(clonedParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('section').to.equal('Products');
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when parameters and segments are provided', (done) => {
+      const segments = ['foo', 'bar'];
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        segments,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('us').to.deep.equal(segments);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when parameters and user id are provided', (done) => {
+      const userId = 'user-id';
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        userId,
+        fetch: fetchSpy,
+      });
+
+      expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestedBodyParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        expect(requestedBodyParams).to.have.property('ui').to.equal(userId);
+        done();
+      }, waitInterval);
+    });
+
+    it('Should throw an error when invalid parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultClick([])).to.be.an('error');
+    });
+
+    it('Should throw an error when no parameters are provided', () => {
+      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
+
+      expect(tracker.trackBrowseResultClick()).to.be.an('error');
     });
   });
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -520,6 +520,89 @@ class Tracker {
   }
 
   /**
+   * Send browse results load event to API
+   *
+   * @function trackBrowseResultLoad
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {number} parameters.result_count - Number of results displayed
+   * @param {number} parameters.result_page - Page number of results
+   * @param {string} parameters.result_id - Result identifier
+   * @param {string} parameters.section - Results section (defaults to "Products")
+   * @param {string} parameters.selected_filters -  Selected filters
+   * @param {string} parameters.sort_order - The sort order ('ascending' or 'descending')
+   * @param {string} parameters.sort_by - The sorting method
+   * @param {string} parameters.filter_name - Filter name
+   * @param {string} parameters.filter_value - Filter value
+   * @returns {(true|Error)}
+   */
+  trackBrowseResultLoad(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const url = `${this.options.serviceUrl}/v2/behavior/browse_result_load`;
+      const bodyParams = {};
+
+      const {
+        result_count,
+        result_page,
+        result_id,
+        section,
+        selected_filters,
+        sort_order,
+        sort_by,
+        filter_name,
+        filter_value,
+      } = parameters;
+
+      if (result_count) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (result_page) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (selected_filters) {
+        bodyParams.selected_filters = selected_filters;
+      }
+
+      if (sort_order) {
+        bodyParams.sort_order = sort_order;
+      }
+
+      if (sort_by) {
+        bodyParams.sort_by = sort_by;
+      }
+
+      if (filter_name) {
+        bodyParams.filter_name = filter_name;
+      }
+
+      if (filter_value) {
+        bodyParams.filter_value = filter_value;
+      }
+
+      this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));
+      this.requests.send();
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
    * Send recommendation click through event to API
    *
    * @function on

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -520,14 +520,14 @@ class Tracker {
   }
 
   /**
-   * Send browse result load event to API
+   * Send browse results loaded event to API
    *
-   * @function trackBrowseResultLoad
+   * @function trackBrowseResultsLoaded
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {number} parameters.result_count - Number of results displayed
-   * @param {number} parameters.result_page - Page number of results
-   * @param {string} parameters.result_id - Result identifier
    * @param {string} [parameters.section="Products"] - Results section
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Result identifier
    * @param {string} [parameters.selected_filters] -  Selected filters
    * @param {string} parameters.sort_order - Sort order ('ascending' or 'descending')
    * @param {string} parameters.sort_by - Sorting method
@@ -535,23 +535,29 @@ class Tracker {
    * @param {string} parameters.filter_value - Filter value
    * @returns {(true|Error)}
    */
-  trackBrowseResultsLoad(parameters) {
+  trackBrowseResultsLoaded(parameters) {
     // Ensure parameters are provided (required)
     if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
       const url = `${this.options.serviceUrl}/v2/behavior/browse_result_load`;
       const bodyParams = {};
 
       const {
+        section,
         result_count,
         result_page,
         result_id,
-        section,
         selected_filters,
         sort_order,
         sort_by,
         filter_name,
         filter_value,
       } = parameters;
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
 
       if (result_count) {
         bodyParams.result_count = result_count;
@@ -563,12 +569,6 @@ class Tracker {
 
       if (result_id) {
         bodyParams.result_id = result_id;
-      }
-
-      if (section) {
-        bodyParams.section = section;
-      } else {
-        bodyParams.section = 'Products';
       }
 
       if (selected_filters) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -607,17 +607,17 @@ class Tracker {
    *
    * @function trackBrowseResultClick
    * @param {object} parameters - Additional parameters to be sent with request
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} [parameters.variation_id] - Variation ID of clicked item
+   * @param {string} [parameters.result_id] - Result identifier
    * @param {number} [parameters.result_count] - Number of results displayed
    * @param {number} [parameters.result_page] - Page number of results
-   * @param {string} [parameters.result_id] - Result identifier
-   * @param {string} [parameters.section="Products"] - Results section
+   * @param {number} [parameters.result_position_on_page] - Position of clicked item
+   * @param {number} [parameters.num_results_per_page] - Number of results shown
    * @param {string} [parameters.selected_filters] -  Selected filters
    * @param {string} parameters.filter_name - Filter name
    * @param {string} parameters.filter_value - Filter value
    * @param {string} parameters.item_id - ID of clicked item
-   * @param {string} [parameters.variation_id] - Variation ID of clicked item
-   * @param {string} [parameters.result_position_on_page] - Position of clicked item
-   * @param {string} [parameters.num_results_per_page] - Number of results shown
    * @returns {(true|Error)}
    */
   trackBrowseResultClick(parameters) {
@@ -627,18 +627,32 @@ class Tracker {
       const bodyParams = {};
 
       const {
+        section,
+        variation_id,
+        result_id,
         result_count,
         result_page,
-        result_id,
-        section,
+        result_position_on_page,
+        num_results_per_page,
         selected_filters,
         filter_name,
         filter_value,
         item_id,
-        variation_id,
-        result_position_on_page,
-        num_results_per_page,
       } = parameters;
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
 
       if (result_count) {
         bodyParams.result_count = result_count;
@@ -648,14 +662,12 @@ class Tracker {
         bodyParams.result_page = result_page;
       }
 
-      if (result_id) {
-        bodyParams.result_id = result_id;
+      if (result_position_on_page) {
+        bodyParams.result_position_on_page = result_position_on_page;
       }
 
-      if (section) {
-        bodyParams.section = section;
-      } else {
-        bodyParams.section = 'Products';
+      if (num_results_per_page) {
+        bodyParams.num_results_per_page = num_results_per_page;
       }
 
       if (selected_filters) {
@@ -672,18 +684,6 @@ class Tracker {
 
       if (item_id) {
         bodyParams.item_id = item_id;
-      }
-
-      if (variation_id) {
-        bodyParams.variation_id = variation_id;
-      }
-
-      if (result_position_on_page) {
-        bodyParams.result_position_on_page = result_position_on_page;
-      }
-
-      if (num_results_per_page) {
-        bodyParams.num_results_per_page = num_results_per_page;
       }
 
       this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -520,22 +520,22 @@ class Tracker {
   }
 
   /**
-   * Send browse results load event to API
+   * Send browse result load event to API
    *
    * @function trackBrowseResultLoad
    * @param {object} parameters - Additional parameters to be sent with request
    * @param {number} parameters.result_count - Number of results displayed
    * @param {number} parameters.result_page - Page number of results
    * @param {string} parameters.result_id - Result identifier
-   * @param {string} parameters.section - Results section (defaults to "Products")
-   * @param {string} parameters.selected_filters -  Selected filters
-   * @param {string} parameters.sort_order - The sort order ('ascending' or 'descending')
-   * @param {string} parameters.sort_by - The sorting method
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} [parameters.selected_filters] -  Selected filters
+   * @param {string} parameters.sort_order - Sort order ('ascending' or 'descending')
+   * @param {string} parameters.sort_by - Sorting method
    * @param {string} parameters.filter_name - Filter name
    * @param {string} parameters.filter_value - Filter value
    * @returns {(true|Error)}
    */
-  trackBrowseResultLoad(parameters) {
+  trackBrowseResultsLoad(parameters) {
     // Ensure parameters are provided (required)
     if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
       const url = `${this.options.serviceUrl}/v2/behavior/browse_result_load`;
@@ -589,6 +589,101 @@ class Tracker {
 
       if (filter_value) {
         bodyParams.filter_value = filter_value;
+      }
+
+      this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));
+      this.requests.send();
+
+      return true;
+    }
+
+    this.requests.send();
+
+    return new Error('parameters are required of type object');
+  }
+
+  /**
+   * Send browse result click event to API
+   *
+   * @function trackBrowseResultClick
+   * @param {object} parameters - Additional parameters to be sent with request
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Result identifier
+   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} [parameters.selected_filters] -  Selected filters
+   * @param {string} parameters.filter_name - Filter name
+   * @param {string} parameters.filter_value - Filter value
+   * @param {string} parameters.item_id - ID of clicked item
+   * @param {string} [parameters.variation_id] - Variation ID of clicked item
+   * @param {string} [parameters.result_position_on_page] - Position of clicked item
+   * @param {string} [parameters.num_results_per_page] - Number of results shown
+   * @returns {(true|Error)}
+   */
+  trackBrowseResultClick(parameters) {
+    // Ensure parameters are provided (required)
+    if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
+      const url = `${this.options.serviceUrl}/v2/behavior/browse_result_click`;
+      const bodyParams = {};
+
+      const {
+        result_count,
+        result_page,
+        result_id,
+        section,
+        selected_filters,
+        filter_name,
+        filter_value,
+        item_id,
+        variation_id,
+        result_position_on_page,
+        num_results_per_page,
+      } = parameters;
+
+      if (result_count) {
+        bodyParams.result_count = result_count;
+      }
+
+      if (result_page) {
+        bodyParams.result_page = result_page;
+      }
+
+      if (result_id) {
+        bodyParams.result_id = result_id;
+      }
+
+      if (section) {
+        bodyParams.section = section;
+      } else {
+        bodyParams.section = 'Products';
+      }
+
+      if (selected_filters) {
+        bodyParams.selected_filters = selected_filters;
+      }
+
+      if (filter_name) {
+        bodyParams.filter_name = filter_name;
+      }
+
+      if (filter_value) {
+        bodyParams.filter_value = filter_value;
+      }
+
+      if (item_id) {
+        bodyParams.item_id = item_id;
+      }
+
+      if (variation_id) {
+        bodyParams.variation_id = variation_id;
+      }
+
+      if (result_position_on_page) {
+        bodyParams.result_position_on_page = result_position_on_page;
+      }
+
+      if (num_results_per_page) {
+        bodyParams.num_results_per_page = num_results_per_page;
       }
 
       this.requests.queue(url, 'POST', applyParams(bodyParams, this.options));


### PR DESCRIPTION
Add browse tracking methods to match changes within autocomplete#1672.

BROWSE RESULT CLICK - browse_result_click
- item_id (string - required)
- variation_id (string)
- section (string)
- result_id (string)
- result_count (integer)
- result_page (integer)
- result_position_on_page (integer)
- num_results_per_page (integer)
- selected_filters (stringlist)
- filter_name (string - required)
- filter_value (string - required)
https://github.com/Constructor-io/autocomplete/blob/master/ingestion_service/src/ingestion_service/blueprints/behavioral_action.py#L97

BROWSE RESULTS LOADED - browse_result_load
- section (string)
- result_id (string)
- result_count (integer)
- result_page (integer)
- selected_filters (stringlist)
- sort_by (string - required)
- sort_order (string - required)
- filter_name (string - required)
- filter_value (string - required)
https://github.com/Constructor-io/autocomplete/blob/master/ingestion_service/src/ingestion_service/blueprints/behavioral_action.py#L106

12 tests added, all tests pass (167/167)

Coverage is stable.