### PR TITLE
Upgrade packages to avoid vulnerabilities, fix flaky test.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "eslint": "^5.12.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.15.0",
-    "http-server": "^0.11.1",
+    "http-server": "^0.12.3",
     "jsdoc": "^3.6.3",
     "jsdom": "^15.1.1",
     "license-checker": "^25.0.1",

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -81,7 +81,7 @@ describe('ConstructorIO - Autocomplete', () => {
     });
 
     it('Should return a response with a valid query, and segments', (done) => {
-      const segments = 'segments';
+      const segments = ['foo', 'bar'];
       const { autocomplete } = new ConstructorIO({
         apiKey: testApiKey,
         segments,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -22,7 +22,7 @@ const { fetch } = fetchPonyfill({ Promise });
 
 describe('ConstructorIO - Tracker', () => {
   const clientVersion = 'cio-mocha';
-  const waitInterval = 700;
+  const waitInterval = 1000;
   let fetchSpy = null;
   let eventSpy = null;
 


### PR DESCRIPTION
Current:
```
audited 730 packages in 3.474s
found 2 vulnerabilities (1 low, 1 high)
  run `npm audit fix` to fix them, or `npm audit` for details
```

Updated:
```
added 728 packages from 1302 contributors and audited 728 packages in 22.171s
found 0 vulnerabilities
```

Fixed a test to send segments as array as it is done in other tests. Updated time to reduce flakiness in runs.