### PR TITLE
Emit events on request response

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ constructorio.tracker.on(messageType, callback);
 ```
 
 #### Dispatched events
-The `search`, `browse` and `recommendations` module may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+The `search`, `browse` and `recommendations` modules may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
 
 ```javascript
 window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {

--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ The status of tracking requests can be observed through emitted events. `message
 constructorio.tracker.on(messageType, callback);
 ```
 
+#### Emitted events
+The `search`, `browse` and `recommendations` module may emit custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+
+```javascript
+window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {
+  // `event.detail` will be response data
+}, false);
+```
+
 ## Development / npm commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ The status of tracking requests can be observed through emitted events. `message
 constructorio.tracker.on(messageType, callback);
 ```
 
-#### Emitted events
-The `search`, `browse` and `recommendations` module may emit custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+#### Dispatched events
+The `search`, `browse` and `recommendations` module may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
 
 ```javascript
 window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -254,6 +254,27 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { browse } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.browse.getBrowseResults.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      browse.getBrowseResults(filterName, filterValue);
+    });
+
     it('Should be rejected when invalid filterName is provided', () => {
       const { browse } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -185,6 +185,27 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.recommendations.getRecommendations.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      recommendations.getRecommendations(podId, { itemIds });
+    });
+
     it('Should be rejected when invalid pod id parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -267,6 +267,27 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.search.getSearchResults.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      search.getSearchResults(query);
+    });
+
     it('Should be rejected when invalid query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -100,6 +100,7 @@ function createBrowseUrl(filterName, filterValue, parameters, options) {
 class Browse {
   constructor(options) {
     this.options = options;
+    this.module = 'browse';
   }
 
   /**
@@ -119,6 +120,7 @@ class Browse {
    */
   getBrowseResults(filterName, filterValue, parameters) {
     let requestUrl;
+    const method = 'getBrowseResults';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     try {
@@ -144,6 +146,8 @@ class Browse {
               result.result_id = json.result_id;
             });
           }
+
+          helpers.dispatchEvent(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -64,6 +64,7 @@ function createRecommendationsUrl(podId, parameters, options) {
 class Recommendations {
   constructor(options) {
     this.options = options;
+    this.module = 'recommendations';
   }
 
   /**
@@ -80,6 +81,7 @@ class Recommendations {
    */
   getRecommendations(podId, parameters) {
     let requestUrl;
+    const method = 'getRecommendations';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     parameters = parameters || {};
@@ -107,6 +109,8 @@ class Recommendations {
               result.result_id = json.result_id;
             });
           }
+
+          helpers.dispatchEvent(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -96,6 +96,7 @@ function createSearchUrl(query, parameters, options) {
 class Search {
   constructor(options) {
     this.options = options;
+    this.module = 'search';
   }
 
   /**
@@ -115,6 +116,7 @@ class Search {
   getSearchResults(query, parameters) {
     let requestUrl;
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
+    const method = 'getSearchResults';
 
     try {
       requestUrl = createSearchUrl(query, parameters, this.options);
@@ -140,11 +142,15 @@ class Search {
             });
           }
 
+          helpers.dispatchEvent(this.module, method, 'response', json);
+
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
+          helpers.dispatchEvent(this.module, method, 'response', json);
+
           return json;
         }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -71,7 +71,7 @@ const utils = {
   dispatchEvent: (module, method, name, data) => {
     const createCustomEvent = (eventName, detail) => {
       try {
-        return new CustomEvent(eventName, { detail });
+        return new window.CustomEvent(eventName, { detail });
       } catch (e) {
         const evt = document.createEvent('CustomEvent');
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -66,6 +66,25 @@ const utils = {
   },
 
   isNil: value => value == null,
+
+  // Dispatch an event on `window` of supplied name and data
+  dispatchEvent: (name, data) => {
+    const createCustomEvent = (name, data) => {
+      try {
+        return new CustomEvent(name, data);
+      } catch (e) {
+        const evt = document.createEvent('CustomEvent');
+
+        evt.initCustomEvent(name, false, false, data);
+
+        return evt;
+      }
+    };
+
+    if (window && window.dispatchEvent) {
+      window.dispatchEvent(createCustomEvent(name, data));
+    }
+  }
 };
 
 module.exports = utils;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -68,23 +68,23 @@ const utils = {
   isNil: value => value == null,
 
   // Dispatch an event on `window` of supplied name and data
-  dispatchEvent: (name, data) => {
-    const createCustomEvent = (name, data) => {
+  dispatchEvent: (module, method, name, data) => {
+    const createCustomEvent = (eventName, detail) => {
       try {
-        return new CustomEvent(name, data);
+        return new CustomEvent(eventName, { detail });
       } catch (e) {
         const evt = document.createEvent('CustomEvent');
 
-        evt.initCustomEvent(name, false, false, data);
+        evt.initCustomEvent(eventName, false, false, detail);
 
         return evt;
       }
     };
 
     if (window && window.dispatchEvent) {
-      window.dispatchEvent(createCustomEvent(name, data));
+      window.dispatchEvent(createCustomEvent(`ConstructorIO.${module}.${method}.${name}`, data));
     }
-  }
+  },
 };
 
 module.exports = utils;


### PR DESCRIPTION
Emit custom events on `window` for search, browse, recommendations modules with response data.

3 tests added. All pass.

Lint passes.