### PR TITLE
Emit events on request response - queued with option to wait for beacon event

### DIFF
--- a/README.md
+++ b/README.md
@@ -295,6 +295,15 @@ The status of tracking requests can be observed through emitted events. `message
 constructorio.tracker.on(messageType, callback);
 ```
 
+#### Emitted events
+The `search`, `browse` and `recommendations` module may emit custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+
+```javascript
+window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {
+  // `event.detail` will be response data
+}, false);
+```
+
 ## Development / npm commands
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -296,10 +296,10 @@ constructorio.tracker.on(messageType, callback);
 ```
 
 #### Dispatched events
-The `search`, `browse` and `recommendations` module may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+The `search`, `browse` and `recommendations` module may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `cio.[moduleName].[methodName].completed`. Example consuming code can be found below:
 
 ```javascript
-window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {
+window.addEventListener('cio.search.getSearchResults.completed', (event) => {
   // `event.detail` will be response data
 }, false);
 ```

--- a/README.md
+++ b/README.md
@@ -295,8 +295,8 @@ The status of tracking requests can be observed through emitted events. `message
 constructorio.tracker.on(messageType, callback);
 ```
 
-#### Emitted events
-The `search`, `browse` and `recommendations` module may emit custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
+#### Dispatched events
+The `search`, `browse` and `recommendations` module may dispatch custom events on `window` with response data when a request has been completed. The event name follows the following structure: `ConstructorIO.[moduleName].[methodName].response`. Example consuming code can be found below:
 
 ```javascript
 window.addEventListener('ConstructorIO.search.getSearchResults.response', (event) => {

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -212,6 +212,32 @@ describe('ConstructorIO - Autocomplete', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { autocomplete } = new ConstructorIO({
+        apiKey: testApiKey,
+        eventDispatcher: {
+          waitForBeacon: false,
+        },
+      });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'cio.autocomplete.getAutocompleteResults.completed';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('sections').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      autocomplete.getAutocompleteResults(query);
+    });
+
     it('Should be rejected when invalid query is provided', () => {
       const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -255,7 +255,12 @@ describe('ConstructorIO - Browse', () => {
     });
 
     it('Should emit an event with response data', (done) => {
-      const { browse } = new ConstructorIO({ apiKey: testApiKey });
+      const { browse } = new ConstructorIO({
+        apiKey: testApiKey,
+        eventDispatcher: {
+          waitForBeacon: false,
+        },
+      });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
       const eventName = 'cio.browse.getBrowseResults.completed';
 

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -257,7 +257,7 @@ describe('ConstructorIO - Browse', () => {
     it('Should emit an event with response data', (done) => {
       const { browse } = new ConstructorIO({ apiKey: testApiKey });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'ConstructorIO.browse.getBrowseResults.response';
+      const eventName = 'cio.browse.getBrowseResults.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -254,6 +254,27 @@ describe('ConstructorIO - Browse', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { browse } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.browse.getBrowseResults.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      browse.getBrowseResults(filterName, filterValue);
+    });
+
     it('Should be rejected when invalid filterName is provided', () => {
       const { browse } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -185,6 +185,27 @@ describe('ConstructorIO - Recommendations', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.recommendations.getRecommendations.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      recommendations.getRecommendations(podId, { itemIds });
+    });
+
     it('Should be rejected when invalid pod id parameter is provided', () => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -186,7 +186,12 @@ describe('ConstructorIO - Recommendations', () => {
     });
 
     it('Should emit an event with response data', (done) => {
-      const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        eventDispatcher: {
+          waitForBeacon: false,
+        },
+      });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
       const eventName = 'cio.recommendations.getRecommendations.completed';
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -188,7 +188,7 @@ describe('ConstructorIO - Recommendations', () => {
     it('Should emit an event with response data', (done) => {
       const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'ConstructorIO.recommendations.getRecommendations.response';
+      const eventName = 'cio.recommendations.getRecommendations.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -268,7 +268,12 @@ describe('ConstructorIO - Search', () => {
     });
 
     it('Should emit an event with response data', (done) => {
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const { search } = new ConstructorIO({
+        apiKey: testApiKey,
+        eventDispatcher: {
+          waitForBeacon: false,
+        },
+      });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
       const eventName = 'cio.search.getSearchResults.completed';
 

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -267,6 +267,27 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
+    it('Should emit an event with response data', (done) => {
+      const { search } = new ConstructorIO({ apiKey: testApiKey });
+      const customEventSpy = sinon.spy(window, 'CustomEvent');
+      const eventName = 'ConstructorIO.search.getSearchResults.response';
+
+      // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+      window.addEventListener(eventName, () => {
+        const customEventSpyArgs = customEventSpy.getCall(0).args;
+        const { detail: customEventDetails } = customEventSpyArgs[1];
+
+        expect(customEventSpy).to.have.been.called;
+        expect(customEventSpyArgs[0]).to.equal(eventName);
+        expect(customEventDetails).to.have.property('request').to.be.an('object');
+        expect(customEventDetails).to.have.property('response').to.be.an('object');
+        expect(customEventDetails).to.have.property('result_id').to.be.an('string');
+        done();
+      }, false);
+
+      search.getSearchResults(query);
+    });
+
     it('Should be rejected when invalid query is provided', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -270,7 +270,7 @@ describe('ConstructorIO - Search', () => {
     it('Should emit an event with response data', (done) => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'ConstructorIO.search.getSearchResults.response';
+      const eventName = 'cio.search.getSearchResults.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -9,7 +9,7 @@ const helpers = require('../../mocha.helpers');
 chai.use(chaiAsPromised);
 dotenv.config();
 
-describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
+describe('ConstructorIO - Utils - Event Dispatcher', () => {
   const eventData = {
     module: 'search',
     method: 'getSearchResults',

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -10,6 +10,7 @@ chai.use(chaiAsPromised);
 dotenv.config();
 
 describe('ConstructorIO - Utils - Event Dispatcher', () => {
+  const beaconEventName = 'cio.beacon.loaded';
   const eventData = {
     module: 'search',
     method: 'getSearchResults',
@@ -73,7 +74,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(eventDispatcher.active).to.equal(false);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
 
-    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+    window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
     expect(eventDispatcher.active).to.equal(true);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
@@ -87,7 +88,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(eventDispatcher.waitForBeacon).to.equal(true);
     expect(dispatchEventsSpy).to.not.have.been.called;
 
-    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+    window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
     expect(eventDispatcher.active).to.equal(true);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
@@ -105,7 +106,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
 
-    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+    window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
     expect(eventDispatcher.events.length).to.equal(0);
     expect(dispatchEventsSpy).to.have.been.called;
@@ -125,7 +126,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
 
-    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+    window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
@@ -180,7 +181,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-      window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+      window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
       eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
 

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -9,7 +9,7 @@ const helpers = require('../../mocha.helpers');
 chai.use(chaiAsPromised);
 dotenv.config();
 
-describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
+describe('ConstructorIO - Utils - Event Dispatcher', () => {
   const beaconEventName = 'cio.beacon.loaded';
   const eventData = {
     module: 'search',

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -1,15 +1,24 @@
-/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-unresolved, no-unused-expressions */
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const store = require('../../../test/utils/store');
+const sinon = require('sinon');
 const EventDispatcher = require('../../../test/utils/event-dispatcher');
 const helpers = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);
 dotenv.config();
 
-describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
+describe('ConstructorIO - Utils - Event Dispatcher', () => {
+  const eventData = {
+    module: 'search',
+    method: 'getSearchResults',
+    name: 'response',
+    data: {
+      foo: 'bar',
+    },
+  };
+
   beforeEach(() => {
     global.CLIENT_VERSION = 'cio-mocha';
 
@@ -27,67 +36,153 @@ describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.enabled).to.be.true;
-    expect(eventDispatcher.waitForBeacon).to.be.false;
+    expect(eventDispatcher.enabled).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(false);
   });
 
   it('Should set correct defaults when enabled option is provided', () => {
-    const eventDispatcher = new EventDispatcher({
-      eventDispatcher: {
-        enabled: false,
-      }
-    });
+    const eventDispatcher = new EventDispatcher({ enabled: false });
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.enabled).to.be.false;
-    expect(eventDispatcher.waitForBeacon).to.be.false;
+    expect(eventDispatcher.enabled).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(false);
   });
 
   it('Should set correct defaults when waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({
-      eventDispatcher: {
-        waitForBeacon: true,
-      }
-    });
+    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.enabled).to.be.false;
-    expect(eventDispatcher.waitForBeacon).to.be.true;
+    expect(eventDispatcher.enabled).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
   });
 
   it('Should set correct defaults when both enabled and waitForBeacon options are provided', () => {
     const eventDispatcher = new EventDispatcher({
-      eventDispatcher: {
-        enabled: true,
-        waitForBeacon: true,
-      }
+      enabled: true,
+      waitForBeacon: true,
     });
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.enabled).to.be.false;
-    expect(eventDispatcher.waitForBeacon).to.be.true;
+    expect(eventDispatcher.enabled).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
   });
 
   it('Should set enabled to be true when beacon event received and waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({
-      eventDispatcher: {
-        waitForBeacon: true,
-      }
-    });
+    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
 
-    expect(eventDispatcher.enabled).to.be.false;
-    expect(eventDispatcher.waitForBeacon).to.be.true;
+    expect(eventDispatcher.enabled).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
 
     window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
 
-    expect(eventDispatcher.enabled).to.be.true;
-    expect(eventDispatcher.waitForBeacon).to.be.true;
+    expect(eventDispatcher.enabled).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+  });
+
+  it('Should set enabled to be true and call dispatchEvents when beacon event received and waitForBeacon option is provided', () => {
+    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+    const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
+
+    expect(eventDispatcher.enabled).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(dispatchEventsSpy).to.not.have.been.called;
+
+    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+
+    expect(eventDispatcher.enabled).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(dispatchEventsSpy).to.have.been.called;
   });
 
   describe('queue', () => {
     it('Should add events to queue when valid options are provided', () => {
+      const eventDispatcher = new EventDispatcher({ enabled: false });
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(eventDispatcher.events.length).to.equal(1);
+      expect(eventDispatcher.events[0]).to.have.property('module').to.be.a('string').to.equal(eventData.module);
+      expect(eventDispatcher.events[0]).to.have.property('method').to.be.a('string').to.equal(eventData.method);
+      expect(eventDispatcher.events[0]).to.have.property('name').to.be.a('string').to.equal(eventData.name);
+      expect(eventDispatcher.events[0]).to.have.property('data').to.be.an('object').to.equal(eventData.data);
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(eventDispatcher.events.length).to.equal(3);
+    });
+
+    it('Should call dispatchEvents method if dispatcher is enabled', () => {
+      const eventDispatcher = new EventDispatcher({ enabled: true });
+      const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(dispatchEventsSpy).to.have.been.called;
+    });
+
+    it('Should not call dispatchEvents method if dispatcher is not enabled', () => {
+      const eventDispatcher = new EventDispatcher({ enabled: false });
+      const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(dispatchEventsSpy).to.not.have.been.called;
+    });
+
+    it('Should not call dispatchEvents method if dispatcher set to waitForBeacon', () => {
+      const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+      const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(dispatchEventsSpy).to.not.have.been.called;
+    });
+
+    it('Should call dispatchEvents method if dispatcher set to waitForBeacon and beacon event is received', () => {
+      const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+      const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
+
+      window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+
+      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+      expect(dispatchEventsSpy).to.have.been.called;
+    });
+  });
+
+  describe('dispatchEvents', () => {
+    it('Should call dispatchEvent if events are queued', () => {
       const eventDispatcher = new EventDispatcher();
+      const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+      eventDispatcher.events = [
+        { ...eventData },
+      ];
+
+      eventDispatcher.dispatchEvents();
+
+      expect(dispatchEventSpy).to.have.been.calledOnce;
+      expect(eventDispatcher.events.length).to.equal(0);
+
+      eventDispatcher.events = [
+        { ...eventData },
+        { ...eventData },
+      ];
+
+      eventDispatcher.dispatchEvents();
+
+      expect(dispatchEventSpy).to.have.been.calledThrice;
+      expect(eventDispatcher.events.length).to.equal(0);
+    });
+
+    it('Should not call dispatchEvent if no events are queued', () => {
+      const eventDispatcher = new EventDispatcher();
+      const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+      eventDispatcher.dispatchEvents();
+
+      expect(dispatchEventSpy).to.not.have.been.called;
     });
   });
 });
-

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -9,7 +9,7 @@ const helpers = require('../../mocha.helpers');
 chai.use(chaiAsPromised);
 dotenv.config();
 
-describe('ConstructorIO - Utils - Event Dispatcher', () => {
+describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
   const beaconEventName = 'cio.beacon.loaded';
   const eventData = {
     module: 'search',
@@ -37,8 +37,8 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.active).to.equal(true);
-    expect(eventDispatcher.waitForBeacon).to.equal(false);
+    expect(eventDispatcher.active).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
   });
 
   it('Should set correct defaults when enabled option is provided', () => {
@@ -46,42 +46,30 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
 
     expect(eventDispatcher.events).to.deep.equal([]);
     expect(eventDispatcher.active).to.equal(false);
-    expect(eventDispatcher.waitForBeacon).to.equal(false);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
   });
 
   it('Should set correct defaults when waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+    const eventDispatcher = new EventDispatcher({ waitForBeacon: false });
 
     expect(eventDispatcher.events).to.deep.equal([]);
-    expect(eventDispatcher.active).to.equal(false);
-    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(eventDispatcher.active).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(false);
   });
 
   it('Should set correct defaults when both enabled and waitForBeacon options are provided', () => {
     const eventDispatcher = new EventDispatcher({
-      enabled: true,
-      waitForBeacon: true,
+      enabled: false,
+      waitForBeacon: false,
     });
 
     expect(eventDispatcher.events).to.deep.equal([]);
     expect(eventDispatcher.active).to.equal(false);
-    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(false);
   });
 
-  it('Should set enabled to be true when beacon event received and waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
-
-    expect(eventDispatcher.active).to.equal(false);
-    expect(eventDispatcher.waitForBeacon).to.equal(true);
-
-    window.dispatchEvent(new window.CustomEvent(beaconEventName));
-
-    expect(eventDispatcher.active).to.equal(true);
-    expect(eventDispatcher.waitForBeacon).to.equal(true);
-  });
-
-  it('Should set enabled to be true and call dispatchEvents when beacon event received and waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+  it('Should set active to be true and call dispatchEvents when beacon event received and waitForBeacon option is provided', () => {
+    const eventDispatcher = new EventDispatcher();
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
     expect(eventDispatcher.active).to.equal(false);
@@ -96,7 +84,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
   });
 
   it('Should not call dispatchEvents until beacon event is received and waitForBeacon option is provided', () => {
-    const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+    const eventDispatcher = new EventDispatcher();
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
     eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
@@ -112,9 +100,8 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(dispatchEventsSpy).to.have.been.called;
   });
 
-  it('Should not call dispatchEvents even if beacon event is received and waitForBeacon option is provided and enabled is set to false', () => {
+  it('Should not call dispatchEvents even if beacon event is received and enabled is set to false', () => {
     const eventDispatcher = new EventDispatcher({
-      waitForBeacon: true,
       enabled: false,
     });
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
@@ -150,8 +137,8 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       expect(eventDispatcher.events.length).to.equal(3);
     });
 
-    it('Should call dispatchEvents method if dispatcher is enabled', () => {
-      const eventDispatcher = new EventDispatcher({ enabled: true });
+    it('Should call dispatchEvents method if dispatcher is enabled and waitForBeacon is set to false', () => {
+      const eventDispatcher = new EventDispatcher({ enabled: true, waitForBeacon: false });
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
       eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
@@ -168,8 +155,8 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       expect(dispatchEventsSpy).to.not.have.been.called;
     });
 
-    it('Should not call dispatchEvents method if dispatcher set to waitForBeacon', () => {
-      const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+    it('Should not call dispatchEvents method until beacon event is received', () => {
+      const eventDispatcher = new EventDispatcher();
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
       eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
@@ -177,8 +164,8 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       expect(dispatchEventsSpy).to.not.have.been.called;
     });
 
-    it('Should call dispatchEvents method if dispatcher set to waitForBeacon and beacon event is received', () => {
-      const eventDispatcher = new EventDispatcher({ waitForBeacon: true });
+    it('Should call dispatchEvents method if beacon event is received', () => {
+      const eventDispatcher = new EventDispatcher();
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
       window.dispatchEvent(new window.CustomEvent(beaconEventName));

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -1,0 +1,93 @@
+/* eslint-disable import/no-unresolved */
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const store = require('../../../test/utils/store');
+const EventDispatcher = require('../../../test/utils/event-dispatcher');
+const helpers = require('../../mocha.helpers');
+
+chai.use(chaiAsPromised);
+dotenv.config();
+
+describe.only('ConstructorIO - Utils - Event Dispatcher', () => {
+  beforeEach(() => {
+    global.CLIENT_VERSION = 'cio-mocha';
+
+    helpers.setupDOM();
+  });
+
+  afterEach(() => {
+    delete global.CLIENT_VERSION;
+
+    helpers.teardownDOM();
+    helpers.clearStorage();
+  });
+
+  it('Should set correct defaults when no options are provided', () => {
+    const eventDispatcher = new EventDispatcher();
+
+    expect(eventDispatcher.events).to.deep.equal([]);
+    expect(eventDispatcher.enabled).to.be.true;
+    expect(eventDispatcher.waitForBeacon).to.be.false;
+  });
+
+  it('Should set correct defaults when enabled option is provided', () => {
+    const eventDispatcher = new EventDispatcher({
+      eventDispatcher: {
+        enabled: false,
+      }
+    });
+
+    expect(eventDispatcher.events).to.deep.equal([]);
+    expect(eventDispatcher.enabled).to.be.false;
+    expect(eventDispatcher.waitForBeacon).to.be.false;
+  });
+
+  it('Should set correct defaults when waitForBeacon option is provided', () => {
+    const eventDispatcher = new EventDispatcher({
+      eventDispatcher: {
+        waitForBeacon: true,
+      }
+    });
+
+    expect(eventDispatcher.events).to.deep.equal([]);
+    expect(eventDispatcher.enabled).to.be.false;
+    expect(eventDispatcher.waitForBeacon).to.be.true;
+  });
+
+  it('Should set correct defaults when both enabled and waitForBeacon options are provided', () => {
+    const eventDispatcher = new EventDispatcher({
+      eventDispatcher: {
+        enabled: true,
+        waitForBeacon: true,
+      }
+    });
+
+    expect(eventDispatcher.events).to.deep.equal([]);
+    expect(eventDispatcher.enabled).to.be.false;
+    expect(eventDispatcher.waitForBeacon).to.be.true;
+  });
+
+  it('Should set enabled to be true when beacon event received and waitForBeacon option is provided', () => {
+    const eventDispatcher = new EventDispatcher({
+      eventDispatcher: {
+        waitForBeacon: true,
+      }
+    });
+
+    expect(eventDispatcher.enabled).to.be.false;
+    expect(eventDispatcher.waitForBeacon).to.be.true;
+
+    window.dispatchEvent(new window.CustomEvent('ConstructorIOAutocomplete.loaded'));
+
+    expect(eventDispatcher.enabled).to.be.true;
+    expect(eventDispatcher.waitForBeacon).to.be.true;
+  });
+
+  describe('queue', () => {
+    it('Should add events to queue when valid options are provided', () => {
+      const eventDispatcher = new EventDispatcher();
+    });
+  });
+});
+

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -26,7 +26,7 @@ class ConstructorIO {
    * @param {boolean} [sendTrackingEvents] - Indicates if tracking events should be dispatched
    * @param {object} [idOptions] - Options object to be supplied to 'constructorio-id' module
    * @param {object} [eventDispatcher] - Options related to 'EventDispatcher' class
-   * @param {boolean} [eventDispatcher.enabled] - Determine if events should be dispatched on `window`
+   * @param {boolean} [eventDispatcher.enabled] - Determine if events should be dispatched
    * @param {boolean} [eventDispatcher.waitForBeacon] - Wait for beacon before dispatching events
    * @property {object} [search] - Interface to {@link module:search}
    * @property {object} [browse] - Interface to {@link module:browse}

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -25,6 +25,9 @@ class ConstructorIO {
    * @param {number} [trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
    * @param {boolean} [sendTrackingEvents] - Indicates if tracking events should be dispatched
    * @param {object} [idOptions] - Options object to be supplied to 'constructorio-id' module
+   * @param {object} [eventDispatcher] - Options related to 'EventDispatcher' class
+   * @param {boolean} [eventDispatcher.enabled] - Determine if events should be dispatched on `window`
+   * @param {boolean} [eventDispatcher.waitForBeacon] - Wait for beacon before dispatching events
    * @property {object} [search] - Interface to {@link module:search}
    * @property {object} [browse] - Interface to {@link module:browse}
    * @property {object} [autocomplete] - Interface to {@link module:autocomplete}
@@ -45,6 +48,7 @@ class ConstructorIO {
       fetch,
       trackingSendDelay,
       sendTrackingEvents,
+      eventDispatcher,
       idOptions,
     } = options;
 
@@ -66,6 +70,7 @@ class ConstructorIO {
       testCells,
       fetch,
       trackingSendDelay,
+      eventDispatcher,
       sendTrackingEvents,
     };
 

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -2,6 +2,7 @@
 const qs = require('qs');
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
+const EventDispatcher = require('../utils/event-dispatcher');
 const { throwHttpErrorFromResponse, cleanParams } = require('../utils/helpers');
 
 // Create URL from supplied query (term) and parameters
@@ -82,7 +83,8 @@ function createAutocompleteUrl(query, parameters, options) {
  */
 class Autocomplete {
   constructor(options) {
-    this.options = options;
+    this.options = options || {};
+    this.eventDispatcher = new EventDispatcher(options.eventDispatcher);
   }
 
   /**
@@ -130,6 +132,8 @@ class Autocomplete {
               }
             });
           }
+
+          this.eventDispatcher.queue('autocomplete', 'getAutocompleteResults', 'completed', json);
 
           return json;
         }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -100,6 +100,7 @@ function createBrowseUrl(filterName, filterValue, parameters, options) {
 class Browse {
   constructor(options) {
     this.options = options;
+    this.module = 'browse';
   }
 
   /**
@@ -119,6 +120,7 @@ class Browse {
    */
   getBrowseResults(filterName, filterValue, parameters) {
     let requestUrl;
+    const method = 'getBrowseResults';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     try {
@@ -144,6 +146,8 @@ class Browse {
               result.result_id = json.result_id;
             });
           }
+
+          helpers.dispatchEvent(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -149,7 +149,7 @@ class Browse {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'completed', json);
 
           return json;
         }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -101,7 +101,6 @@ function createBrowseUrl(filterName, filterValue, parameters, options) {
 class Browse {
   constructor(options) {
     this.options = options;
-    this.module = 'browse';
     this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
   }
 
@@ -122,7 +121,6 @@ class Browse {
    */
   getBrowseResults(filterName, filterValue, parameters) {
     let requestUrl;
-    const method = 'getBrowseResults';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     try {
@@ -149,7 +147,7 @@ class Browse {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'completed', json);
+          this.eventDispatcher.queue('browse', 'getBrowseResults', 'completed', json);
 
           return json;
         }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -100,8 +100,8 @@ function createBrowseUrl(filterName, filterValue, parameters, options) {
  */
 class Browse {
   constructor(options) {
-    this.options = options;
-    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
+    this.options = options || {};
+    this.eventDispatcher = new EventDispatcher(options.eventDispatcher);
   }
 
   /**

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -102,7 +102,7 @@ class Browse {
   constructor(options) {
     this.options = options;
     this.module = 'browse';
-    this.eventDispatcher = new EventDispatcher();
+    this.eventDispatcher = new EventDispatcher(options);
   }
 
   /**

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -102,7 +102,7 @@ class Browse {
   constructor(options) {
     this.options = options;
     this.module = 'browse';
-    this.eventDispatcher = new EventDispatcher(options);
+    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
   }
 
   /**

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -2,6 +2,7 @@
 const qs = require('qs');
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
+const EventDispatcher = require('../utils/event-dispatcher');
 const helpers = require('../utils/helpers');
 
 // Create URL from supplied filter name, value and parameters
@@ -101,6 +102,7 @@ class Browse {
   constructor(options) {
     this.options = options;
     this.module = 'browse';
+    this.eventDispatcher = new EventDispatcher();
   }
 
   /**
@@ -147,7 +149,7 @@ class Browse {
             });
           }
 
-          helpers.dispatchEvent(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -66,7 +66,7 @@ class Recommendations {
   constructor(options) {
     this.options = options;
     this.module = 'recommendations';
-    this.eventDispatcher = new EventDispatcher(options);
+    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
   }
 
   /**

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -112,7 +112,7 @@ class Recommendations {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'completed', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -64,6 +64,7 @@ function createRecommendationsUrl(podId, parameters, options) {
 class Recommendations {
   constructor(options) {
     this.options = options;
+    this.module = 'recommendations';
   }
 
   /**
@@ -80,6 +81,7 @@ class Recommendations {
    */
   getRecommendations(podId, parameters) {
     let requestUrl;
+    const method = 'getRecommendations';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     parameters = parameters || {};
@@ -107,6 +109,8 @@ class Recommendations {
               result.result_id = json.result_id;
             });
           }
+
+          helpers.dispatchEvent(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -2,6 +2,7 @@
 const qs = require('qs');
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
+const EventDispatcher = require('../utils/event-dispatcher');
 const helpers = require('../utils/helpers');
 
 // Create URL from supplied parameters
@@ -65,6 +66,7 @@ class Recommendations {
   constructor(options) {
     this.options = options;
     this.module = 'recommendations';
+    this.eventDispatcher = new EventDispatcher();
   }
 
   /**
@@ -110,7 +112,7 @@ class Recommendations {
             });
           }
 
-          helpers.dispatchEvent(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -83,7 +83,6 @@ class Recommendations {
    */
   getRecommendations(podId, parameters) {
     let requestUrl;
-    const method = 'getRecommendations';
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
 
     parameters = parameters || {};
@@ -112,7 +111,7 @@ class Recommendations {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'completed', json);
+          this.eventDispatcher.queue('recommendations', 'getRecommendations', 'completed', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -66,7 +66,7 @@ class Recommendations {
   constructor(options) {
     this.options = options;
     this.module = 'recommendations';
-    this.eventDispatcher = new EventDispatcher();
+    this.eventDispatcher = new EventDispatcher(options);
   }
 
   /**

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -64,9 +64,8 @@ function createRecommendationsUrl(podId, parameters, options) {
  */
 class Recommendations {
   constructor(options) {
-    this.options = options;
-    this.module = 'recommendations';
-    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
+    this.options = options || {};
+    this.eventDispatcher = new EventDispatcher(options.eventDispatcher);
   }
 
   /**

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -144,14 +144,14 @@ class Search {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'completed', json);
 
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
-          this.eventDispatcher.queue(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'completed', json);
 
           return json;
         }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -96,9 +96,8 @@ function createSearchUrl(query, parameters, options) {
  */
 class Search {
   constructor(options) {
-    this.options = options;
-    this.module = 'search';
-    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
+    this.options = options || {};
+    this.eventDispatcher = new EventDispatcher(options.eventDispatcher);
   }
 
   /**
@@ -118,7 +117,6 @@ class Search {
   getSearchResults(query, parameters) {
     let requestUrl;
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
-    const method = 'getSearchResults';
 
     try {
       requestUrl = createSearchUrl(query, parameters, this.options);
@@ -144,14 +142,14 @@ class Search {
             });
           }
 
-          this.eventDispatcher.queue(this.module, method, 'completed', json);
+          this.eventDispatcher.queue('search', 'getSearchResults', 'completed', json);
 
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
-          this.eventDispatcher.queue(this.module, method, 'completed', json);
+          this.eventDispatcher.queue('search', 'getSearchResults', 'completed', json);
 
           return json;
         }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -2,6 +2,7 @@
 const qs = require('qs');
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
+const EventDispatcher = require('../utils/event-dispatcher');
 const helpers = require('../utils/helpers');
 
 // Create URL from supplied query (term) and parameters
@@ -97,6 +98,7 @@ class Search {
   constructor(options) {
     this.options = options;
     this.module = 'search';
+    this.eventDispatcher = new EventDispatcher();
   }
 
   /**
@@ -142,14 +144,14 @@ class Search {
             });
           }
 
-          helpers.dispatchEvent(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'response', json);
 
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
-          helpers.dispatchEvent(this.module, method, 'response', json);
+          this.eventDispatcher.queue(this.module, method, 'response', json);
 
           return json;
         }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -98,7 +98,7 @@ class Search {
   constructor(options) {
     this.options = options;
     this.module = 'search';
-    this.eventDispatcher = new EventDispatcher(options);
+    this.eventDispatcher = new EventDispatcher(options && options.eventDispatcher);
   }
 
   /**

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -98,7 +98,7 @@ class Search {
   constructor(options) {
     this.options = options;
     this.module = 'search';
-    this.eventDispatcher = new EventDispatcher();
+    this.eventDispatcher = new EventDispatcher(options);
   }
 
   /**

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -96,6 +96,7 @@ function createSearchUrl(query, parameters, options) {
 class Search {
   constructor(options) {
     this.options = options;
+    this.module = 'search';
   }
 
   /**
@@ -115,6 +116,7 @@ class Search {
   getSearchResults(query, parameters) {
     let requestUrl;
     const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
+    const method = 'getSearchResults';
 
     try {
       requestUrl = createSearchUrl(query, parameters, this.options);
@@ -140,11 +142,15 @@ class Search {
             });
           }
 
+          helpers.dispatchEvent(this.module, method, 'response', json);
+
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
+          helpers.dispatchEvent(this.module, method, 'response', json);
+
           return json;
         }
 

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-unneeded-ternary */
+const helpers = require('../utils/helpers');
 
 // Create `CustomEvent` with fallback
 const createCustomEvent = (eventName, detail) => {
@@ -23,8 +24,14 @@ class EventDispatcher {
       ? true
       : false; // Defaults to 'false'
 
+    // If `waitForBeacon` option is set, only enable event dispatching once event is received from beacon
     if (this.waitForBeacon) {
       this.enabled = false;
+
+      // Mark if page environment is unloading
+      helpers.addEventListener('ConstructorIOAutocomplete.loaded', () => {
+        this.enabled = true;
+      });
     }
   }
 

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -20,9 +20,9 @@ class EventDispatcher {
     this.enabled = (options && options.enabled === false)
       ? false
       : true; // Defaults to 'true'
-    this.waitForBeacon = (options && options.waitForBeacon === true)
-      ? true
-      : false; // Defaults to 'false'
+    this.waitForBeacon = (options && options.waitForBeacon === false)
+      ? false
+      : true; // Defaults to 'true'
 
     // `enabled` is a supplied option
     // - if false, events will never be dispatched

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -1,0 +1,47 @@
+// Create `CustomEvent` with fallback
+const createCustomEvent = (eventName, detail) => {
+  try {
+    return new window.CustomEvent(eventName, { detail });
+  } catch (e) {
+    const evt = document.createEvent('CustomEvent');
+
+    evt.initCustomEvent(eventName, false, false, detail);
+
+    return evt;
+  }
+};
+
+class EventDispatcher {
+  constructor() {
+    this.events = [];
+    this.active = true;
+  }
+
+  // Push event data to queue
+  queue(module, method, name, data) {
+    this.events.push({
+      module,
+      method,
+      name,
+      data,
+    });
+
+    if (this.active) {
+      this.dispatchEvents();
+    }
+  }
+
+  // Dispatch all custom events within queue on `window` of supplied name with data
+  dispatchEvents() {
+    if (this.events.length) {
+      this.events.forEach((item) => {
+        const { module, method, name, data } = item;
+        const eventName = `ConstructorIO.${module}.${method}.${name}`;
+
+        window.dispatchEvent(createCustomEvent(eventName, data));
+      });
+    }
+  }
+}
+
+module.exports = EventDispatcher;

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -24,15 +24,23 @@ class EventDispatcher {
       ? true
       : false; // Defaults to 'false'
 
+    // `enabled` is a supplied option
+    // - if false, events will never be dispatched
+    // `active` is a variable determining if events will be dispatched
+    // - if `waitForBeacon` is set to true, `active` will be false until beacon event is received
+    this.active = this.enabled;
+
     // If `waitForBeacon` option is set, only enable event dispatching once event is received from beacon
     if (this.waitForBeacon) {
-      this.enabled = false;
+      this.active = false;
 
       // Mark if page environment is unloading
       helpers.addEventListener('ConstructorIOAutocomplete.loaded', () => {
-        this.enabled = true;
+        if (this.enabled) {
+          this.active = true;
 
-        this.dispatchEvents();
+          this.dispatchEvents();
+        }
       });
     }
   }
@@ -46,7 +54,7 @@ class EventDispatcher {
       data,
     });
 
-    if (this.enabled) {
+    if (this.active) {
       this.dispatchEvents();
     }
   }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -35,7 +35,7 @@ class EventDispatcher {
       this.active = false;
 
       // Mark if page environment is unloading
-      helpers.addEventListener('ConstructorIOAutocomplete.loaded', () => {
+      helpers.addEventListener('cio.beacon.loaded', () => {
         if (this.enabled) {
           this.active = true;
 
@@ -65,7 +65,7 @@ class EventDispatcher {
       while (this.events.length) {
         const item = this.events.pop();
         const { module, method, name, data } = item;
-        const eventName = `ConstructorIO.${module}.${method}.${name}`;
+        const eventName = `cio.${module}.${method}.${name}`;
 
         window.dispatchEvent(createCustomEvent(eventName, data));
       }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -17,10 +17,10 @@ const createCustomEvent = (eventName, detail) => {
 class EventDispatcher {
   constructor(options) {
     this.events = [];
-    this.enabled = (options && options.eventDispatcher && options.eventDispatcher.enabled === false)
+    this.enabled = (options && options.enabled === false)
       ? false
       : true; // Defaults to 'true'
-    this.waitForBeacon = (options && options.eventDispatcher && options.eventDispatcher.waitForBeacon === true)
+    this.waitForBeacon = (options && options.waitForBeacon === true)
       ? true
       : false; // Defaults to 'false'
 
@@ -31,6 +31,8 @@ class EventDispatcher {
       // Mark if page environment is unloading
       helpers.addEventListener('ConstructorIOAutocomplete.loaded', () => {
         this.enabled = true;
+
+        this.dispatchEvents();
       });
     }
   }
@@ -52,12 +54,13 @@ class EventDispatcher {
   // Dispatch all custom events within queue on `window` of supplied name with data
   dispatchEvents() {
     if (this.events.length) {
-      this.events.forEach((item) => {
+      while (this.events.length) {
+        const item = this.events.pop();
         const { module, method, name, data } = item;
         const eventName = `ConstructorIO.${module}.${method}.${name}`;
 
         window.dispatchEvent(createCustomEvent(eventName, data));
-      });
+      }
     }
   }
 }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-unneeded-ternary */
+
 // Create `CustomEvent` with fallback
 const createCustomEvent = (eventName, detail) => {
   try {
@@ -12,9 +14,18 @@ const createCustomEvent = (eventName, detail) => {
 };
 
 class EventDispatcher {
-  constructor() {
+  constructor(options) {
     this.events = [];
-    this.active = true;
+    this.enabled = (options && options.eventDispatcher && options.eventDispatcher.enabled === false)
+      ? false
+      : true; // Defaults to 'true'
+    this.waitForBeacon = (options && options.eventDispatcher && options.eventDispatcher.waitForBeacon === true)
+      ? true
+      : false; // Defaults to 'false'
+
+    if (this.waitForBeacon) {
+      this.enabled = false;
+    }
   }
 
   // Push event data to queue
@@ -26,7 +37,7 @@ class EventDispatcher {
       data,
     });
 
-    if (this.active) {
+    if (this.enabled) {
       this.dispatchEvents();
     }
   }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -62,7 +62,7 @@ class EventDispatcher {
   // Dispatch all custom events within queue on `window` of supplied name with data
   dispatchEvents() {
     while (this.events.length) {
-      const item = this.events.pop();
+      const item = this.events.shift();
       const { module, method, name, data } = item;
       const eventName = `cio.${module}.${method}.${name}`;
 

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -34,7 +34,7 @@ class EventDispatcher {
     if (this.waitForBeacon) {
       this.active = false;
 
-      // Mark if page environment is unloading
+      // Bind listener to beacon loaded event
       helpers.addEventListener('cio.beacon.loaded', () => {
         if (this.enabled) {
           this.active = true;
@@ -61,14 +61,12 @@ class EventDispatcher {
 
   // Dispatch all custom events within queue on `window` of supplied name with data
   dispatchEvents() {
-    if (this.events.length) {
-      while (this.events.length) {
-        const item = this.events.pop();
-        const { module, method, name, data } = item;
-        const eventName = `cio.${module}.${method}.${name}`;
+    while (this.events.length) {
+      const item = this.events.pop();
+      const { module, method, name, data } = item;
+      const eventName = `cio.${module}.${method}.${name}`;
 
-        window.dispatchEvent(createCustomEvent(eventName, data));
-      }
+      window.dispatchEvent(createCustomEvent(eventName, data));
     }
   }
 }

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -66,25 +66,6 @@ const utils = {
   },
 
   isNil: value => value == null,
-
-  // Dispatch an event on `window` of supplied name and data
-  dispatchEvent: (module, method, name, data) => {
-    const createCustomEvent = (eventName, detail) => {
-      try {
-        return new window.CustomEvent(eventName, { detail });
-      } catch (e) {
-        const evt = document.createEvent('CustomEvent');
-
-        evt.initCustomEvent(eventName, false, false, detail);
-
-        return evt;
-      }
-    };
-
-    if (window && window.dispatchEvent) {
-      window.dispatchEvent(createCustomEvent(`ConstructorIO.${module}.${method}.${name}`, data));
-    }
-  },
 };
 
 module.exports = utils;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -71,7 +71,7 @@ const utils = {
   dispatchEvent: (module, method, name, data) => {
     const createCustomEvent = (eventName, detail) => {
       try {
-        return new CustomEvent(eventName, { detail });
+        return new window.CustomEvent(eventName, { detail });
       } catch (e) {
         const evt = document.createEvent('CustomEvent');
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -66,6 +66,25 @@ const utils = {
   },
 
   isNil: value => value == null,
+
+  // Dispatch an event on `window` of supplied name and data
+  dispatchEvent: (name, data) => {
+    const createCustomEvent = (name, data) => {
+      try {
+        return new CustomEvent(name, data);
+      } catch (e) {
+        const evt = document.createEvent('CustomEvent');
+
+        evt.initCustomEvent(name, false, false, data);
+
+        return evt;
+      }
+    };
+
+    if (window && window.dispatchEvent) {
+      window.dispatchEvent(createCustomEvent(name, data));
+    }
+  }
 };
 
 module.exports = utils;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -68,23 +68,23 @@ const utils = {
   isNil: value => value == null,
 
   // Dispatch an event on `window` of supplied name and data
-  dispatchEvent: (name, data) => {
-    const createCustomEvent = (name, data) => {
+  dispatchEvent: (module, method, name, data) => {
+    const createCustomEvent = (eventName, detail) => {
       try {
-        return new CustomEvent(name, data);
+        return new CustomEvent(eventName, { detail });
       } catch (e) {
         const evt = document.createEvent('CustomEvent');
 
-        evt.initCustomEvent(name, false, false, data);
+        evt.initCustomEvent(eventName, false, false, detail);
 
         return evt;
       }
     };
 
     if (window && window.dispatchEvent) {
-      window.dispatchEvent(createCustomEvent(name, data));
+      window.dispatchEvent(createCustomEvent(`ConstructorIO.${module}.${method}.${name}`, data));
     }
-  }
+  },
 };
 
 module.exports = utils;

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -1,4 +1,4 @@
-/* eslint-disable brace-style */
+/* eslint-disable brace-style, no-unneeded-ternary */
 const fetchPonyfill = require('fetch-ponyfill');
 const Promise = require('es6-promise');
 const store = require('../utils/store');
@@ -15,8 +15,9 @@ class RequestQueue {
     this.requestPending = false;
     this.pageUnloading = false;
 
-    // eslint-disable-next-line no-unneeded-ternary
-    this.sendTrackingEvents = (options && options.sendTrackingEvents === false) ? false : true;
+    this.sendTrackingEvents = (options && options.sendTrackingEvents === false)
+      ? false
+      : true; // Defaults to 'true'
 
     // Mark if page environment is unloading
     helpers.addEventListener('beforeunload', () => {


### PR DESCRIPTION
- Events are now queued
- `eventDispatcher` parameters can now be specified on instantiation.
- `eventDispatcher.enabled` defaults to TRUE. If set to FALSE, no events will ever be dispatched
- `eventDispatcher.waitForBeacon` will disable event dispatching until a custom event (`cio.beacon.loaded`) is received on `window`. Once received, all queued events will be dispatched until queue is exhausted.

Full test coverage added for new class (`EventDispatcher`) - 15 in total.

Continued from #45 