### PR TITLE
Improve wait for beacon functionality

### DIFF
--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -62,7 +62,7 @@ describe('ConstructorIO', () => {
       },
     };
     const customEventSpy = sinon.spy(window, 'CustomEvent');
-    const eventName = 'cio.constructor.instantiation.completed';
+    const eventName = 'cio.client.instantiated';
 
     // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
     window.addEventListener(eventName, () => {

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -1,5 +1,6 @@
-/* eslint-disable import/no-unresolved */
+/* eslint-disable no-unused-expressions, import/no-unresolved, no-new */
 const jsdom = require('mocha-jsdom');
+const sinon = require('sinon');
 const ConstructorIO = require('../../test/constructorio');
 
 const validApiKey = 'testing';
@@ -51,6 +52,32 @@ describe('ConstructorIO', () => {
     expect(instance.options).to.have.property('sessionId').to.equal(sessionId);
     expect(instance.options).to.have.property('serviceUrl').to.equal(serviceUrl);
     expect(instance.options).to.have.property('version').to.equal(version);
+  });
+
+  it('Should emit an event with options data', (done) => {
+    const options = {
+      apiKey: validApiKey,
+      eventDispatcher: {
+        waitForBeacon: false,
+      },
+    };
+    const customEventSpy = sinon.spy(window, 'CustomEvent');
+    const eventName = 'cio.constructor.instantiation.completed';
+
+    // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
+    window.addEventListener(eventName, () => {
+      const customEventSpyArgs = customEventSpy.getCall(0).args;
+      const { detail: customEventDetails } = customEventSpyArgs[1];
+
+      expect(customEventSpy).to.have.been.called;
+      expect(customEventSpyArgs[0]).to.equal(eventName);
+      expect(customEventDetails).to.be.an('object');
+      expect(customEventDetails).to.have.property('apiKey').to.equal(options.apiKey);
+      expect(customEventDetails).to.have.property('eventDispatcher').to.deep.equal(options.eventDispatcher);
+      done();
+    }, false);
+
+    new ConstructorIO(options);
   });
 
   it('Should throw an error when invalid API key is provided', () => {

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -220,7 +220,7 @@ describe('ConstructorIO - Autocomplete', () => {
         },
       });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'cio.autocomplete.getAutocompleteResults.completed';
+      const eventName = 'cio.client.autocomplete.getAutocompleteResults.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -262,7 +262,7 @@ describe('ConstructorIO - Browse', () => {
         },
       });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'cio.browse.getBrowseResults.completed';
+      const eventName = 'cio.client.browse.getBrowseResults.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -193,7 +193,7 @@ describe('ConstructorIO - Recommendations', () => {
         },
       });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'cio.recommendations.getRecommendations.completed';
+      const eventName = 'cio.client.recommendations.getRecommendations.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -275,7 +275,7 @@ describe('ConstructorIO - Search', () => {
         },
       });
       const customEventSpy = sinon.spy(window, 'CustomEvent');
-      const eventName = 'cio.search.getSearchResults.completed';
+      const eventName = 'cio.client.search.getSearchResults.completed';
 
       // Note: `CustomEvent` in Node context not containing `detail`, so checking arguments instead
       window.addEventListener(eventName, () => {

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -12,9 +12,7 @@ dotenv.config();
 describe('ConstructorIO - Utils - Event Dispatcher', () => {
   const beaconEventName = 'cio.beacon.loaded';
   const eventData = {
-    module: 'search',
-    method: 'getSearchResults',
-    name: 'response',
+    name: 'search.getSearchResults.completed',
     data: {
       foo: 'bar',
     },
@@ -89,7 +87,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.active).to.equal(true);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
@@ -102,7 +100,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.active).to.equal(true);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
@@ -115,7 +113,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.active).to.equal(true);
     expect(eventDispatcher.waitForBeacon).to.equal(true);
@@ -126,9 +124,9 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
@@ -145,9 +143,9 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     });
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
@@ -166,9 +164,9 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     });
     const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
 
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.name, eventData.data);
 
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventSpy).to.not.have.been.called;
@@ -178,16 +176,14 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     it('Should add events to queue when valid options are provided', () => {
       const eventDispatcher = new EventDispatcher({ enabled: false });
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(eventDispatcher.events.length).to.equal(1);
-      expect(eventDispatcher.events[0]).to.have.property('module').to.be.a('string').to.equal(eventData.module);
-      expect(eventDispatcher.events[0]).to.have.property('method').to.be.a('string').to.equal(eventData.method);
       expect(eventDispatcher.events[0]).to.have.property('name').to.be.a('string').to.equal(eventData.name);
       expect(eventDispatcher.events[0]).to.have.property('data').to.be.an('object').to.equal(eventData.data);
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(eventDispatcher.events.length).to.equal(3);
     });
@@ -196,7 +192,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       const eventDispatcher = new EventDispatcher({ enabled: true, waitForBeacon: false });
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(dispatchEventsSpy).to.have.been.called;
     });
@@ -205,7 +201,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       const eventDispatcher = new EventDispatcher({ enabled: false });
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(dispatchEventsSpy).to.not.have.been.called;
     });
@@ -214,7 +210,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
       const eventDispatcher = new EventDispatcher();
       const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(dispatchEventsSpy).to.not.have.been.called;
     });
@@ -225,7 +221,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
 
       window.dispatchEvent(new window.CustomEvent(beaconEventName));
 
-      eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+      eventDispatcher.queue(eventData.name, eventData.data);
 
       expect(dispatchEventsSpy).to.have.been.called;
     });

--- a/spec/src/utils/event-dispatcher.js
+++ b/spec/src/utils/event-dispatcher.js
@@ -68,7 +68,7 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(eventDispatcher.waitForBeacon).to.equal(false);
   });
 
-  it('Should set active to be true and call dispatchEvents when beacon event received and waitForBeacon option is provided', () => {
+  it('Should set active to be true and call dispatchEvents when beacon event received', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
@@ -83,7 +83,46 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
     expect(dispatchEventsSpy).to.have.been.called;
   });
 
-  it('Should not call dispatchEvents until beacon event is received and waitForBeacon option is provided', () => {
+  it('Should set active to be true and call dispatchEvents when beacon window objects found - `ConstructorioAutocomplete`', () => {
+    window.ConstructorioAutocomplete = true;
+
+    const eventDispatcher = new EventDispatcher();
+    const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+    expect(eventDispatcher.active).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(dispatchEventSpy).to.have.been.called;
+  });
+
+  it('Should set active to be true and call dispatchEvents when beacon window objects found - `ConstructorioBeacon`', () => {
+    window.ConstructorioBeacon = true;
+
+    const eventDispatcher = new EventDispatcher();
+    const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+    expect(eventDispatcher.active).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(dispatchEventSpy).to.have.been.called;
+  });
+
+  it('Should set active to be true and call dispatchEvents when beacon window objects found - `ConstructorioTracker`', () => {
+    window.ConstructorioTracker = true;
+
+    const eventDispatcher = new EventDispatcher();
+    const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+    expect(eventDispatcher.active).to.equal(true);
+    expect(eventDispatcher.waitForBeacon).to.equal(true);
+    expect(dispatchEventSpy).to.have.been.called;
+  });
+
+  it('Should not call dispatchEvents until beacon event is received', () => {
     const eventDispatcher = new EventDispatcher();
     const dispatchEventsSpy = sinon.spy(eventDispatcher, 'dispatchEvents');
 
@@ -117,6 +156,22 @@ describe('ConstructorIO - Utils - Event Dispatcher', () => {
 
     expect(eventDispatcher.events.length).to.equal(3);
     expect(dispatchEventsSpy).to.not.have.been.called;
+  });
+
+  it('Should not call dispatchEvents even if beacon window object is found and enabled is set to false', () => {
+    window.ConstructorioAutocomplete = true;
+
+    const eventDispatcher = new EventDispatcher({
+      enabled: false,
+    });
+    const dispatchEventSpy = sinon.spy(window, 'dispatchEvent');
+
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+    eventDispatcher.queue(eventData.module, eventData.method, eventData.name, eventData.data);
+
+    expect(eventDispatcher.events.length).to.equal(3);
+    expect(dispatchEventSpy).to.not.have.been.called;
   });
 
   describe('queue', () => {

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -7,6 +7,7 @@ const Browse = require('./modules/browse');
 const Autocomplete = require('./modules/autocomplete');
 const Recommendations = require('./modules/recommendations');
 const Tracker = require('./modules/tracker');
+const EventDispatcher = require('./utils/event-dispatcher');
 const { version: packageVersion } = require('../package.json');
 
 /**
@@ -80,6 +81,9 @@ class ConstructorIO {
     this.autocomplete = new Autocomplete(this.options);
     this.recommendations = new Recommendations(this.options);
     this.tracker = new Tracker(this.options);
+
+    // Dispatch initialization event
+    new EventDispatcher(options.eventDispatcher).queue('constructor', 'instantiation', 'completed', this.options);
   }
 }
 

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -83,7 +83,7 @@ class ConstructorIO {
     this.tracker = new Tracker(this.options);
 
     // Dispatch initialization event
-    new EventDispatcher(options.eventDispatcher).queue('constructor', 'instantiation', 'completed', this.options);
+    new EventDispatcher(options.eventDispatcher).queue('instantiated', this.options);
   }
 }
 

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -133,7 +133,7 @@ class Autocomplete {
             });
           }
 
-          this.eventDispatcher.queue('autocomplete', 'getAutocompleteResults', 'completed', json);
+          this.eventDispatcher.queue('autocomplete.getAutocompleteResults.completed', json);
 
           return json;
         }

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -147,7 +147,7 @@ class Browse {
             });
           }
 
-          this.eventDispatcher.queue('browse', 'getBrowseResults', 'completed', json);
+          this.eventDispatcher.queue('browse.getBrowseResults.completed', json);
 
           return json;
         }

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -110,7 +110,7 @@ class Recommendations {
             });
           }
 
-          this.eventDispatcher.queue('recommendations', 'getRecommendations', 'completed', json);
+          this.eventDispatcher.queue('recommendations.getRecommendations.completed', json);
 
           return json;
         }

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -142,14 +142,14 @@ class Search {
             });
           }
 
-          this.eventDispatcher.queue('search', 'getSearchResults', 'completed', json);
+          this.eventDispatcher.queue('search.getSearchResults.completed', json);
 
           return json;
         }
 
         // Redirect rules
         if (json.response && json.response.redirect) {
-          this.eventDispatcher.queue('search', 'getSearchResults', 'completed', json);
+          this.eventDispatcher.queue('search.getSearchResults.completed', json);
 
           return json;
         }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -61,10 +61,8 @@ class EventDispatcher {
   }
 
   // Push event data to queue
-  queue(module, method, name, data) {
+  queue(name, data) {
     this.events.push({
-      module,
-      method,
       name,
       data,
     });
@@ -78,8 +76,8 @@ class EventDispatcher {
   dispatchEvents() {
     while (this.events.length) {
       const item = this.events.shift();
-      const { module, method, name, data } = item;
-      const eventName = `cio.${module}.${method}.${name}`;
+      const { name, data } = item;
+      const eventName = `cio.client.${name}`;
 
       window.dispatchEvent(createCustomEvent(eventName, data));
     }

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -34,7 +34,18 @@ class EventDispatcher {
     if (this.waitForBeacon) {
       this.active = false;
 
+      // Check browser environment to determine if beacon has been loaded
+      // - Important for the case where the beacon has loaded before client library instantiated
+      if (window.ConstructorioAutocomplete || window.ConstructorioBeacon) {
+        if (this.enabled) {
+          this.active = true;
+
+          this.dispatchEvents();
+        }
+      }
+
       // Bind listener to beacon loaded event
+      // - Important for the case where client library instantiated before beacon has loaded
       helpers.addEventListener('cio.beacon.loaded', () => {
         if (this.enabled) {
           this.active = true;

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -36,7 +36,11 @@ class EventDispatcher {
 
       // Check browser environment to determine if beacon has been loaded
       // - Important for the case where the beacon has loaded before client library instantiated
-      if (window.ConstructorioAutocomplete || window.ConstructorioBeacon) {
+      if (
+        window.ConstructorioAutocomplete
+        || window.ConstructorioBeacon
+        || window.ConstructorioTracker
+      ) {
         if (this.enabled) {
           this.active = true;
 


### PR DESCRIPTION
Currently, events will only be dispatched when the beacon is loaded _after_ the client library, as it waits for the beacon event (assuming `waitForBeacon` is true).

If the beacon is loaded before the client library is instantiated, the event listener hasn't yet been bound within the client library. The event goes unheard, and no events are dispatched.

Checking the window for presence of the beacon should help alleviate this concern.

Bonus: dispatch instantiation event when client library is initialized.

Emitted event naming structure updated to include `client`, for example:

`cio.client.search.getSearchResults.completed`
`cio.client.instantiated`