### PR TITLE
[CH10918] Add support for items browse result load tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ constructorio.tracker.trackSearchResultsLoaded('dogs', {
 | Parameter | Type | Required |
 | --- | --- | :---: |
 | `num_results` | string | ✔ |
-| `customer_ids` | string | |
+| `customer_ids` | array | |
 
 #### Send search result click event
 ```javascript
@@ -208,7 +208,7 @@ constructorio.tracker.trackPurchase({
 
 | Parameter | Type | Required |
 | --- | --- | :---: |
-| `customer_ids` | string | ✔ |
+| `customer_ids` | array | ✔ |
 | `revenue` | string | ✔ |
 | `section` | string | |
 
@@ -268,6 +268,7 @@ constructorio.tracker.trackBrowseResultsLoaded({
 | `selected_filters` | string or array | |
 | `sort_by` | string | |
 | `sort_order` | string | |
+| `items` | array | |
 
 #### Send browse result click event
 ```javascript

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1863,6 +1863,15 @@ describe('ConstructorIO - Tracker', () => {
       result_page: 1,
       result_id: 'result-id',
       selected_filters: { foo: ['bar'] },
+      items: [
+        {
+          item_id: '123',
+          variation_id: '456',
+        },
+        {
+          item_id: '789'
+        },
+      ],
     };
 
     it('Should respond with a valid response when required parameters are provided', (done) => {
@@ -2035,6 +2044,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('result_page').to.equal(optionalParameters.result_page);
         expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
         expect(requestParams).to.have.property('selected_filters').to.deep.equal(optionalParameters.selected_filters);
+        expect(requestParams).to.have.property('items').to.deep.equal(optionalParameters.items);
 
         // Response
         expect(eventSpy).to.have.been.called;

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1869,7 +1869,7 @@ describe('ConstructorIO - Tracker', () => {
           variation_id: '456',
         },
         {
-          item_id: '789'
+          item_id: '789',
         },
       ],
     };

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -583,6 +583,7 @@ class Tracker {
    * @param {string} [parameters.selected_filters] -  Selected filters
    * @param {string} [parameters.sort_order] - Sort order ('ascending' or 'descending')
    * @param {string} [parameters.sort_by] - Sorting method
+   * @param {array} [parameters.items] - List of objects of customer items returned from browse
    * @param {string} parameters.url - Current page URL
    * @param {string} parameters.filter_name - Filter name
    * @param {string} parameters.filter_value - Filter value
@@ -605,6 +606,7 @@ class Tracker {
         sort_by,
         filter_name,
         filter_value,
+        items,
       } = parameters;
 
       if (section) {
@@ -647,6 +649,10 @@ class Tracker {
 
       if (filter_value) {
         bodyParams.filter_value = filter_value;
+      }
+
+      if (items && Array.isArray(items)) {
+        bodyParams.items = items;
       }
 
       this.requests.queue(`${requestUrl}${applyParamsAsString({}, this.options)}`, 'POST', applyParams(bodyParams, this.options));


### PR DESCRIPTION
As this is a `v2` endpoint, the parameter name is different (not `customer_ids`). Confirmed with backend that this is the correct parameter name and data structure.

Test modified and new functionality is covered.