### PR TITLE
Add ability to provide optional term parameter which applies to specific strategies.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,8 +116,9 @@ constructorio.recommendations.getRecommendations('pod-id', { parameters }).then(
 | Parameter | Type | Description |
 | --- | --- | --- |
 | `numResults` | number | Number of results to retrieve |
-| `itemIds` | string or array | Item ID(s) to retrieve recommendations for |
+| `itemIds` | string or array | Item ID(s) to retrieve recommendations for (strategy specific) |
 | `section` | string | Section to display results from |
+| `term` | string | Term to retrieve recommendations for (strategy specific) |
 
 ### Tracker
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -36,6 +36,7 @@ describe('ConstructorIO - Recommendations', () => {
 
   describe('getRecommendations', () => {
     const podId = 'item_page_1';
+    const queryRecommendationsPodId = 'query_recommendations';
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
@@ -84,6 +85,29 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res.response.pod).to.have.property('id').to.equal(podId);
         expect(res.response.pod).to.have.property('display_name');
         expect(requestedUrlParams).to.have.property('item_id').to.deep.equal(itemIds);
+        done();
+      });
+    });
+
+    it('Should return a response with valid term for query recommendations strategy pod', (done) => {
+      const term = 'apple';
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendations(queryRecommendationsPodId, { term }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(res.request.term).to.deep.equal(term);
+        expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response).to.have.property('pod');
+        expect(res.response.pod).to.have.property('id').to.equal(queryRecommendationsPodId);
+        expect(res.response.pod).to.have.property('display_name');
+        expect(requestedUrlParams).to.have.property('term').to.deep.equal(term);
         done();
       });
     });

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -30,7 +30,7 @@ function createRecommendationsUrl(podId, parameters, options) {
   }
 
   if (parameters) {
-    const { numResults, itemIds, section } = parameters;
+    const { numResults, itemIds, section, term } = parameters;
 
     // Pull num results number from parameters
     if (!helpers.isNil(numResults)) {
@@ -45,6 +45,11 @@ function createRecommendationsUrl(podId, parameters, options) {
     // Pull section from parameters
     if (section) {
       queryParams.section = section;
+    }
+
+    // Pull term from parameters
+    if (term) {
+      queryParams.term = term;
     }
   }
 
@@ -74,9 +79,10 @@ class Recommendations {
    * @function getRecommendations
    * @param {string} podId - Pod identifier
    * @param {object} [parameters] - Additional parameters to refine results
-   * @param {string|array} [parameters.itemIds] - Item ID(s) to retrieve recommendations for
+   * @param {string|array} [parameters.itemIds] - Item ID(s) to retrieve recommendations for (strategy specific)
    * @param {number} [parameters.numResults] - The number of results to return
    * @param {string} [parameters.section] - The section to return results from
+   * @param {string} [parameters.term] - The term to use to refine results (strategy specific)
    * @returns {Promise}
    * @see https://docs.constructor.io
    */


### PR DESCRIPTION
New `query_recommendations` (utilized for zero-results) strategy requires a `term` to return results for.

✅  222 passing (2m)
✅  Lint passes