### PR TITLE
[CH11185] Disable dispatch of tracking events by default

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -26,9 +26,7 @@ describe('ConstructorIO - Tracker', () => {
   let fetchSpy = null;
   let eventSpy = null;
   const requestQueueOptions = {
-    requestQueue: {
-      sendTrackingEvents: true,
-    },
+    sendTrackingEvents: true,
   };
 
   jsdom({ url: 'http://localhost' });

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -25,6 +25,11 @@ describe('ConstructorIO - Tracker', () => {
   const waitInterval = 1000;
   let fetchSpy = null;
   let eventSpy = null;
+  const requestQueueOptions = {
+    requestQueue: {
+      sendTrackingEvents: true,
+    },
+  };
 
   jsdom({ url: 'http://localhost' });
 
@@ -51,6 +56,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -85,6 +91,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -114,6 +121,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -143,6 +151,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -176,6 +185,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -207,6 +217,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -241,6 +252,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -269,6 +281,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -297,6 +310,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -338,6 +352,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -374,6 +389,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -402,6 +418,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -430,6 +447,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -456,6 +474,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -523,6 +542,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -558,6 +578,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -586,6 +607,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -614,6 +636,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -640,6 +663,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -704,6 +728,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -739,6 +764,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -767,6 +793,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -795,6 +822,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -821,6 +849,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -850,6 +879,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -911,6 +941,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -947,6 +978,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -975,6 +1007,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1003,6 +1036,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1068,6 +1102,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1104,6 +1139,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1142,6 +1178,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1172,6 +1209,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1200,6 +1238,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1228,6 +1267,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1291,6 +1331,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1324,6 +1365,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1355,6 +1397,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1381,6 +1424,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1410,6 +1454,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1438,6 +1483,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1490,6 +1536,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1526,6 +1573,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1556,6 +1604,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1584,6 +1633,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1612,6 +1662,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1638,6 +1689,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1698,6 +1750,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1733,6 +1786,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1763,6 +1817,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1791,6 +1846,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1819,6 +1875,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1845,6 +1902,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1915,6 +1973,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1952,6 +2011,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -1982,6 +2042,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2010,6 +2071,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2038,6 +2100,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2064,6 +2127,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2126,6 +2190,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2161,6 +2226,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2191,6 +2257,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         segments,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2219,6 +2286,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         userId,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2247,6 +2315,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         testCells,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2273,6 +2342,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.on('success', eventSpy);
@@ -2344,6 +2414,7 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
+        ...requestQueueOptions,
       });
 
       tracker.trackSessionStart();
@@ -2361,6 +2432,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         serviceUrl: 'http://constructor.io',
+        ...requestQueueOptions,
       });
 
       tracker.trackSessionStart();
@@ -2378,6 +2450,7 @@ describe('ConstructorIO - Tracker', () => {
         apiKey: testApiKey,
         fetch: fetchSpy,
         serviceUrl: 'invalid',
+        ...requestQueueOptions,
       });
 
       tracker.trackSessionStart();

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -92,7 +92,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
 
-    it('Should add requests to the queue if the sendTrackingRequests option is false', () => {
+    it('Should add requests to the queue if the sendTrackingEvents option is false', () => {
       const requests = new RequestQueue({
         requestQueue: {
           sendTrackingEvents: false,
@@ -107,7 +107,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       helpers.triggerUnload();
     });
 
-    it('Should not add requests to the queue if the sendTrackingRequests option is not defined', () => {
+    it('Should add requests to the queue if the sendTrackingEvents option is not defined', () => {
       const requests = new RequestQueue();
 
       requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
@@ -343,6 +343,44 @@ describe('ConstructorIO - Utils - Request Queue', () => {
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
         helpers.triggerUnload();
+        requests.send();
+
+        setTimeout(() => {
+          expect(RequestQueue.get()).to.be.an('array').length(3);
+          done();
+        }, waitInterval);
+      });
+
+      it('Should not send any tracking requests if queue is populated and user is human and sendTrackingEvents is set to false', (done) => {
+        const requests = new RequestQueue({
+          requestQueue: {
+            sendTrackingEvents: false,
+          },
+        });
+
+        requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
+        requests.queue('https://ac.cnstrc.com/behavior?action=focus');
+        requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+
+        expect(RequestQueue.get()).to.be.an('array').length(3);
+        helpers.triggerResize();
+        requests.send();
+
+        setTimeout(() => {
+          expect(RequestQueue.get()).to.be.an('array').length(3);
+          done();
+        }, waitInterval);
+      });
+
+      it('Should not send any tracking requests if queue is populated and user is human and sendTrackingEvents is not defined', (done) => {
+        const requests = new RequestQueue();
+
+        requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
+        requests.queue('https://ac.cnstrc.com/behavior?action=focus');
+        requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+
+        expect(RequestQueue.get()).to.be.an('array').length(3);
+        helpers.triggerResize();
         requests.send();
 
         setTimeout(() => {

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -15,6 +15,11 @@ dotenv.config();
 describe('ConstructorIO - Utils - Request Queue', () => {
   const storageKey = '_constructorio_requests';
   const waitInterval = 700;
+  const requestQueueOptions = {
+    requestQueue: {
+      sendTrackingEvents: true,
+    },
+  };
 
   describe('queue', () => {
     let defaultAgent;
@@ -37,7 +42,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
     it('Should add url requests to the queue', () => {
-      const requests = new RequestQueue();
+      const requests = new RequestQueue(requestQueueOptions);
 
       requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
       requests.queue('https://ac.cnstrc.com/behavior?action=focus');
@@ -49,7 +54,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
     it('Should add object requests to the queue - POST with body', () => {
-      const requests = new RequestQueue();
+      const requests = new RequestQueue(requestQueueOptions);
 
       requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'session_start' });
       requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'focus' });
@@ -61,7 +66,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
     it('Should not add requests to the queue if the user has a bot-like useragent', () => {
-      const requests = new RequestQueue();
+      const requests = new RequestQueue(requestQueueOptions);
 
       window.navigator.__defineGetter__('userAgent', () => 'Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko; compatible; Googlebot/2.1; +http://www.google.com/bot.html) Safari/537.36');
 
@@ -74,7 +79,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
     it('Should not add requests to the queue if the user is webdriver', () => {
-      const requests = new RequestQueue();
+      const requests = new RequestQueue(requestQueueOptions);
 
       window.navigator.__defineGetter__('webdriver', () => true);
 
@@ -87,16 +92,29 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
 
-    it('Should not add requests to the queue if the sendTrackingRequests option is false', () => {
+    it('Should add requests to the queue if the sendTrackingRequests option is false', () => {
       const requests = new RequestQueue({
-        sendTrackingEvents: false,
+        requestQueue: {
+          sendTrackingEvents: false,
+        },
       });
 
       requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
       requests.queue('https://ac.cnstrc.com/behavior?action=focus');
       requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
 
-      expect(RequestQueue.get()).to.be.an('array').length(0);
+      expect(RequestQueue.get()).to.be.an('array').length(3);
+      helpers.triggerUnload();
+    });
+
+    it('Should not add requests to the queue if the sendTrackingRequests option is not defined', () => {
+      const requests = new RequestQueue();
+
+      requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
+      requests.queue('https://ac.cnstrc.com/behavior?action=focus');
+      requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+
+      expect(RequestQueue.get()).to.be.an('array').length(3);
       helpers.triggerUnload();
     });
   });
@@ -117,7 +135,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
 
     describe('Single Instance', () => {
       it('Should send all url tracking requests if queue is populated and user is human', (done) => {
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
         requests.queue('https://ac.cnstrc.com/behavior?action=focus');
@@ -134,7 +152,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should send all object tracking requests if queue is populated and user is human - POST with body', (done) => {
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'session_start' });
         requests.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'focus' });
@@ -151,7 +169,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should not send tracking requests if queue is populated and user is not human', (done) => {
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
         requests.queue('https://ac.cnstrc.com/behavior?action=focus');
@@ -167,7 +185,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should not send tracking requests if queue is populated and user is human and page is unloading', (done) => {
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
         requests.queue('https://ac.cnstrc.com/behavior?action=focus');
@@ -185,7 +203,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should not send tracking requests if queue is populated and user is human and page is unloading and send was called before unload', (done) => {
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
         requests.queue('https://ac.cnstrc.com/behavior?action=focus');
@@ -209,7 +227,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
           'https://ac.cnstrc.com/behavior?action=magic_number_three',
         ]);
 
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
@@ -237,7 +255,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
           },
         ]);
 
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
@@ -266,7 +284,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
         ]);
 
         // eslint-disable-next-line no-unused-vars
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
@@ -293,7 +311,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
           },
         ]);
 
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         expect(RequestQueue.get()).to.be.an('array').length(3);
         requests.send();
@@ -320,7 +338,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
           },
         ]);
 
-        const requests = new RequestQueue();
+        const requests = new RequestQueue(requestQueueOptions);
 
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
@@ -359,8 +377,8 @@ describe('ConstructorIO - Utils - Request Queue', () => {
           },
         ]);
 
-        const requests1 = new RequestQueue();
-        const requests2 = new RequestQueue();
+        const requests1 = new RequestQueue(requestQueueOptions);
+        const requests2 = new RequestQueue(requestQueueOptions);
         const sendSpy1 = sinon.spy(requests1, 'send');
         const sendSpy2 = sinon.spy(requests2, 'send');
 
@@ -379,8 +397,8 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should send tracking requests using multiple queues when items are queued in one and user is human', (done) => {
-        const requests1 = new RequestQueue();
-        const requests2 = new RequestQueue();
+        const requests1 = new RequestQueue(requestQueueOptions);
+        const requests2 = new RequestQueue(requestQueueOptions);
         const sendSpy1 = sinon.spy(requests1, 'send');
         const sendSpy2 = sinon.spy(requests2, 'send');
 
@@ -404,8 +422,8 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       });
 
       it('Should send tracking requests using multiple queues when items are queued in both and user is human', (done) => {
-        const requests1 = new RequestQueue();
-        const requests2 = new RequestQueue();
+        const requests1 = new RequestQueue(requestQueueOptions);
+        const requests2 = new RequestQueue(requestQueueOptions);
         const sendSpy1 = sinon.spy(requests1, 'send');
         const sendSpy2 = sinon.spy(requests2, 'send');
 

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -92,7 +92,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
     });
 
 
-    it('Should add requests to the queue if the sendTrackingEvents option is false', () => {
+    it('Should not add requests to the queue if the sendTrackingEvents option is false', () => {
       const requests = new RequestQueue({
         requestQueue: {
           sendTrackingEvents: false,
@@ -103,18 +103,18 @@ describe('ConstructorIO - Utils - Request Queue', () => {
       requests.queue('https://ac.cnstrc.com/behavior?action=focus');
       requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
 
-      expect(RequestQueue.get()).to.be.an('array').length(3);
+      expect(RequestQueue.get()).to.be.an('array').length(0);
       helpers.triggerUnload();
     });
 
-    it('Should add requests to the queue if the sendTrackingEvents option is not defined', () => {
+    it('Should not add requests to the queue if the sendTrackingEvents option is not defined', () => {
       const requests = new RequestQueue();
 
       requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
       requests.queue('https://ac.cnstrc.com/behavior?action=focus');
       requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
 
-      expect(RequestQueue.get()).to.be.an('array').length(3);
+      expect(RequestQueue.get()).to.be.an('array').length(0);
       helpers.triggerUnload();
     });
   });
@@ -343,44 +343,6 @@ describe('ConstructorIO - Utils - Request Queue', () => {
         expect(RequestQueue.get()).to.be.an('array').length(3);
         helpers.triggerResize();
         helpers.triggerUnload();
-        requests.send();
-
-        setTimeout(() => {
-          expect(RequestQueue.get()).to.be.an('array').length(3);
-          done();
-        }, waitInterval);
-      });
-
-      it('Should not send any tracking requests if queue is populated and user is human and sendTrackingEvents is set to false', (done) => {
-        const requests = new RequestQueue({
-          requestQueue: {
-            sendTrackingEvents: false,
-          },
-        });
-
-        requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
-        requests.queue('https://ac.cnstrc.com/behavior?action=focus');
-        requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
-
-        expect(RequestQueue.get()).to.be.an('array').length(3);
-        helpers.triggerResize();
-        requests.send();
-
-        setTimeout(() => {
-          expect(RequestQueue.get()).to.be.an('array').length(3);
-          done();
-        }, waitInterval);
-      });
-
-      it('Should not send any tracking requests if queue is populated and user is human and sendTrackingEvents is not defined', (done) => {
-        const requests = new RequestQueue();
-
-        requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
-        requests.queue('https://ac.cnstrc.com/behavior?action=focus');
-        requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
-
-        expect(RequestQueue.get()).to.be.an('array').length(3);
-        helpers.triggerResize();
         requests.send();
 
         setTimeout(() => {

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -16,9 +16,7 @@ describe('ConstructorIO - Utils - Request Queue', () => {
   const storageKey = '_constructorio_requests';
   const waitInterval = 700;
   const requestQueueOptions = {
-    requestQueue: {
-      sendTrackingEvents: true,
-    },
+    sendTrackingEvents: true,
   };
 
   describe('queue', () => {

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -25,6 +25,9 @@ class ConstructorIO {
    * @param {function} [fetch] - If supplied, will be utilized for requests rather than default Fetch API
    * @param {number} [trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
    * @param {boolean} [sendTrackingEvents] - Indicates if tracking events should be dispatched
+   * @param {object} [requestQueue] - Options related to 'RequestQueue' class
+   * @param {boolean} [requestQueue.sendTrackingEvents] - Indicates if tracking events should be dispatched
+   * @param {boolean} [requestQueue.trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
    * @param {object} [idOptions] - Options object to be supplied to 'constructorio-id' module
    * @param {object} [eventDispatcher] - Options related to 'EventDispatcher' class
    * @param {boolean} [eventDispatcher.enabled] - Determine if events should be dispatched
@@ -47,8 +50,7 @@ class ConstructorIO {
       sessionId,
       userId,
       fetch,
-      trackingSendDelay,
-      sendTrackingEvents,
+      requestQueue,
       eventDispatcher,
       idOptions,
     } = options;
@@ -70,9 +72,8 @@ class ConstructorIO {
       segments,
       testCells,
       fetch,
-      trackingSendDelay,
+      requestQueue,
       eventDispatcher,
-      sendTrackingEvents,
     };
 
     // Expose global modules

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -23,9 +23,8 @@ class ConstructorIO {
    * @param {string} [sessionId] - Session id, defaults to value supplied by 'constructorio-id' module
    * @param {string} [userId] - User ID
    * @param {function} [fetch] - If supplied, will be utilized for requests rather than default Fetch API
-   * @param {object} [requestQueue] - Options related to 'RequestQueue' class
-   * @param {boolean} [requestQueue.sendTrackingEvents] - Indicates if tracking events should be dispatched
-   * @param {boolean} [requestQueue.trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
+   * @param {number} [trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
+   * @param {boolean} [sendTrackingEvents] - Indicates if tracking events should be dispatched
    * @param {object} [idOptions] - Options object to be supplied to 'constructorio-id' module
    * @param {object} [eventDispatcher] - Options related to 'EventDispatcher' class
    * @param {boolean} [eventDispatcher.enabled] - Determine if events should be dispatched
@@ -48,7 +47,8 @@ class ConstructorIO {
       sessionId,
       userId,
       fetch,
-      requestQueue,
+      trackingSendDelay,
+      sendTrackingEvents,
       eventDispatcher,
       idOptions,
     } = options;
@@ -70,7 +70,8 @@ class ConstructorIO {
       segments,
       testCells,
       fetch,
-      requestQueue,
+      trackingSendDelay,
+      sendTrackingEvents,
       eventDispatcher,
     };
 

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -23,8 +23,6 @@ class ConstructorIO {
    * @param {string} [sessionId] - Session id, defaults to value supplied by 'constructorio-id' module
    * @param {string} [userId] - User ID
    * @param {function} [fetch] - If supplied, will be utilized for requests rather than default Fetch API
-   * @param {number} [trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)
-   * @param {boolean} [sendTrackingEvents] - Indicates if tracking events should be dispatched
    * @param {object} [requestQueue] - Options related to 'RequestQueue' class
    * @param {boolean} [requestQueue.sendTrackingEvents] - Indicates if tracking events should be dispatched
    * @param {boolean} [requestQueue.trackingSendDelay] - Amount of time to wait before sending tracking events (in ms)

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -33,7 +33,7 @@ class RequestQueue {
 
   // Add request to queue to be dispatched
   queue(url, method = 'GET', body) {
-    if (!this.humanity.isBot()) {
+    if (this.sendTrackingEvents && !this.humanity.isBot()) {
       const queue = RequestQueue.get();
 
       queue.push({

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -15,11 +15,9 @@ class RequestQueue {
     this.requestPending = false;
     this.pageUnloading = false;
 
-    this.sendTrackingEvents = (
-      options
-      && options.requestQueue
-      && options.requestQueue.sendTrackingEvents === true
-    ) ? true : false; // Defaults to 'false'
+    this.sendTrackingEvents = (options && options.sendTrackingEvents === true)
+      ? true
+      : false; // Defaults to 'false'
 
     // Mark if page environment is unloading
     helpers.addEventListener('beforeunload', () => {
@@ -128,11 +126,7 @@ class RequestQueue {
             });
           }
         }
-      }, (
-        this.options
-        && this.options.requestQueue
-        && this.options.requestQueue.trackingSendDelay
-      ) || 25);
+      }, (this.options && this.options.trackingSendDelay) || 25);
     }
   }
 

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -15,21 +15,25 @@ class RequestQueue {
     this.requestPending = false;
     this.pageUnloading = false;
 
-    this.sendTrackingEvents = (options && options.sendTrackingEvents === false)
-      ? false
-      : true; // Defaults to 'true'
+    this.sendTrackingEvents = (
+      options
+      && options.requestQueue
+      && options.requestQueue.sendTrackingEvents === true
+    ) ? true : false; // Defaults to 'false'
 
     // Mark if page environment is unloading
     helpers.addEventListener('beforeunload', () => {
       this.pageUnloading = true;
     });
 
-    this.send();
+    if (this.sendTrackingEvents) {
+      this.send();
+    }
   }
 
   // Add request to queue to be dispatched
   queue(url, method = 'GET', body) {
-    if (this.sendTrackingEvents && !this.humanity.isBot()) {
+    if (!this.humanity.isBot()) {
       const queue = RequestQueue.get();
 
       queue.push({
@@ -43,87 +47,93 @@ class RequestQueue {
 
   // Read from queue and send requests to server
   send() {
-    // Defer sending of events to give beforeunload time to register (avoids race condition)
-    setTimeout(() => {
-      const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
-      const queue = RequestQueue.get();
+    if (this.sendTrackingEvents) {
+      // Defer sending of events to give beforeunload time to register (avoids race condition)
+      setTimeout(() => {
+        const fetch = (this.options && this.options.fetch) || fetchPonyfill({ Promise }).fetch;
+        const queue = RequestQueue.get();
 
-      if (
-        this.humanity.isHuman()
-        && !this.requestPending
-        && !this.pageUnloading
-        && queue.length
-      ) {
-        let request;
-        let nextInQueue = queue.shift();
+        if (
+          this.humanity.isHuman()
+          && !this.requestPending
+          && !this.pageUnloading
+          && queue.length
+        ) {
+          let request;
+          let nextInQueue = queue.shift();
 
-        RequestQueue.set(queue);
+          RequestQueue.set(queue);
 
-        // Backwards compatibility with versions <= 2.0.0, can be removed in future
-        // - Request queue entries used to be strings with 'GET' method assumed
-        if (typeof nextInQueue === 'string') {
-          nextInQueue = {
-            url: nextInQueue,
-            method: 'GET',
-          };
-        }
+          // Backwards compatibility with versions <= 2.0.0, can be removed in future
+          // - Request queue entries used to be strings with 'GET' method assumed
+          if (typeof nextInQueue === 'string') {
+            nextInQueue = {
+              url: nextInQueue,
+              method: 'GET',
+            };
+          }
 
-        if (nextInQueue.method === 'GET') {
-          request = fetch(nextInQueue.url);
-        }
+          if (nextInQueue.method === 'GET') {
+            request = fetch(nextInQueue.url);
+          }
 
-        if (nextInQueue.method === 'POST') {
-          request = fetch(nextInQueue.url, {
-            method: nextInQueue.method,
-            body: JSON.stringify(nextInQueue.body),
-            mode: 'cors',
-            headers: { 'Content-Type': 'text/plain' },
-          });
-        }
+          if (nextInQueue.method === 'POST') {
+            request = fetch(nextInQueue.url, {
+              method: nextInQueue.method,
+              body: JSON.stringify(nextInQueue.body),
+              mode: 'cors',
+              headers: { 'Content-Type': 'text/plain' },
+            });
+          }
 
-        if (request) {
-          this.requestPending = true;
-          const instance = this;
+          if (request) {
+            this.requestPending = true;
+            const instance = this;
 
-          request.then((response) => {
-            // Request was successful, and returned a 2XX status code
-            if (response.ok) {
-              instance.eventemitter.emit('success', {
+            request.then((response) => {
+              // Request was successful, and returned a 2XX status code
+              if (response.ok) {
+                instance.eventemitter.emit('success', {
+                  url: nextInQueue.url,
+                  method: nextInQueue.method,
+                  message: 'ok',
+                });
+              }
+
+              // Request was successful, but returned a non-2XX status code
+              else {
+                response.json().then((json) => {
+                  instance.eventemitter.emit('error', {
+                    url: nextInQueue.url,
+                    method: nextInQueue.method,
+                    message: json && json.message,
+                  });
+                }).catch((error) => {
+                  instance.eventemitter.emit('error', {
+                    url: nextInQueue.url,
+                    method: nextInQueue.method,
+                    message: error.type,
+                  });
+                });
+              }
+            }).catch((error) => {
+              instance.eventemitter.emit('error', {
                 url: nextInQueue.url,
                 method: nextInQueue.method,
-                message: 'ok',
+                message: error.toString(),
               });
-            }
-
-            // Request was successful, but returned a non-2XX status code
-            else {
-              response.json().then((json) => {
-                instance.eventemitter.emit('error', {
-                  url: nextInQueue.url,
-                  method: nextInQueue.method,
-                  message: json && json.message,
-                });
-              }).catch((error) => {
-                instance.eventemitter.emit('error', {
-                  url: nextInQueue.url,
-                  method: nextInQueue.method,
-                  message: error.type,
-                });
-              });
-            }
-          }).catch((error) => {
-            instance.eventemitter.emit('error', {
-              url: nextInQueue.url,
-              method: nextInQueue.method,
-              message: error.toString(),
+            }).finally(() => {
+              this.requestPending = false;
+              this.send();
             });
-          }).finally(() => {
-            this.requestPending = false;
-            this.send();
-          });
+          }
         }
-      }
-    }, (this.options && this.options.trackingSendDelay) || 25);
+      }, (
+        this.options
+        && this.options.requestQueue
+        && this.options.requestQueue.trackingSendDelay
+      ) || 25);
+    }
   }
 
   // Return current request queue


### PR DESCRIPTION
✅  All tests pass (225/225)

- `sendTrackingEvents` is now defaulted to false within request queue, meaning we will not dispatch events from the library when default options are supplied

- Changed logic so that events can still be queued (stored in localstorage) but will never be sent if `sendTrackingEvents` is not true

- Moved options relating to request queue into an options object rather than having them as individual options

- Updated all tests

Easier to view diff with [?w=1](https://github.com/Constructor-io/constructorio-client-javascript/pull/59/files?w=1)