### PR TITLE
[CH11188] Support supplying filters to getRecommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ constructorio.autocomplete.getAutocompleteResults('dogs', {
 | `section` | string | Section to display results from |
 | `numResults` | number | Number of results to retrieve |
 | `resultsPerSection` | object | Object of pairs in the form of `section: number` for number results to display |
-| `filters` | object | The criteria by which search results should be filtered |
+| `filters` | object | Filters used to refine results |
 | `sortOrder` | string | The sort order by which search results should be sorted (descending or ascending) |
 
 ### Recommendations
@@ -121,6 +121,7 @@ constructorio.recommendations.getRecommendations('pod-id', { parameters }).then(
 | `itemIds` | string or array | Item ID(s) to retrieve recommendations for (strategy specific) |
 | `section` | string | Section to display results from |
 | `term` | string | Term to retrieve recommendations for (strategy specific) |
+| `filters` | object | Filters used to refine results (strategy specific) |
 
 ### Tracker
 

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -37,6 +37,7 @@ describe('ConstructorIO - Recommendations', () => {
   describe('getRecommendations', () => {
     const podId = 'item_page_1';
     const queryRecommendationsPodId = 'query_recommendations';
+    const filteredItemsRecommendationsPodId = 'filtered_items';
     const itemId = 'power_drill';
     const itemIds = [itemId, 'drill'];
 
@@ -108,6 +109,57 @@ describe('ConstructorIO - Recommendations', () => {
         expect(res.response.pod).to.have.property('id').to.equal(queryRecommendationsPodId);
         expect(res.response.pod).to.have.property('display_name');
         expect(requestedUrlParams).to.have.property('term').to.deep.equal(term);
+        done();
+      });
+    });
+
+    it('Should return a response with valid filters for filtered items strategy pod', (done) => {
+      const filters = { keywords: 'battery-powered' };
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendations(filteredItemsRecommendationsPodId, { filters }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(res.request.filters).to.deep.equal(filters);
+        expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response).to.have.property('pod');
+        expect(res.response.pod).to.have.property('id').to.equal(filteredItemsRecommendationsPodId);
+        expect(res.response.pod).to.have.property('display_name');
+        expect(requestedUrlParams).to.have.property('filters').to.deep.equal(filters);
+        done();
+      });
+    });
+
+    it('Should return a response with valid filters and item id for filtered items strategy pod', (done) => {
+      const filters = { keywords: 'battery-powered' };
+      const { recommendations } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+      });
+
+      recommendations.getRecommendations(filteredItemsRecommendationsPodId, {
+        filters,
+        itemIds: itemId,
+      }).then((res) => {
+        const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        expect(res).to.have.property('request').to.be.an('object');
+        expect(res).to.have.property('response').to.be.an('object');
+        expect(res).to.have.property('result_id').to.be.an('string');
+        expect(res.request.filters).to.deep.equal(filters);
+        expect(res.request.item_id).to.equal(itemId);
+        expect(res.response).to.have.property('results').to.be.an('array');
+        expect(res.response).to.have.property('pod');
+        expect(res.response.pod).to.have.property('id').to.equal(filteredItemsRecommendationsPodId);
+        expect(res.response.pod).to.have.property('display_name');
+        expect(requestedUrlParams).to.have.property('filters').to.deep.equal(filters);
+        expect(requestedUrlParams).to.have.property('item_id').to.equal(itemId);
         done();
       });
     });

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -113,9 +113,9 @@ class Browse {
    * @param {object} [parameters] - Additional parameters to refine result set
    * @param {number} [parameters.page] - The page number of the results
    * @param {number} [parameters.resultsPerPage] - The number of results per page to return
-   * @param {object} [parameters.filters] - Filters used to refine
-   * @param {string} [parameters.sortBy='relevance'] - The sorting method
-   * @param {string} [parameters.sortOrder='descending'] - The sort order for search results
+   * @param {object} [parameters.filters] - Filters used to refine results
+   * @param {string} [parameters.sortBy='relevance'] - The sort method for results
+   * @param {string} [parameters.sortOrder='descending'] - The sort order for results
    * @returns {Promise}
    * @see https://docs.constructor.io
    */

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -30,7 +30,7 @@ function createRecommendationsUrl(podId, parameters, options) {
   }
 
   if (parameters) {
-    const { numResults, itemIds, section, term } = parameters;
+    const { numResults, itemIds, section, term, filters } = parameters;
 
     // Pull num results number from parameters
     if (!helpers.isNil(numResults)) {
@@ -50,6 +50,11 @@ function createRecommendationsUrl(podId, parameters, options) {
     // Pull term from parameters
     if (term) {
       queryParams.term = term;
+    }
+
+    // Pull filters from parameters
+    if (filters) {
+      queryParams.filters = filters;
     }
   }
 
@@ -83,6 +88,7 @@ class Recommendations {
    * @param {number} [parameters.numResults] - The number of results to return
    * @param {string} [parameters.section] - The section to return results from
    * @param {string} [parameters.term] - The term to use to refine results (strategy specific)
+   * @param {object} [parameters.filters] - Filters used to refine results (strategy specific)
    * @returns {Promise}
    * @see https://docs.constructor.io
    */
@@ -97,7 +103,6 @@ class Recommendations {
     } catch (e) {
       return Promise.reject(e);
     }
-
 
     return fetch(requestUrl)
       .then((response) => {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -114,8 +114,8 @@ class Search {
    * @param {number} [parameters.page] - The page number of the results
    * @param {number} [parameters.resultsPerPage] - The number of results per page to return
    * @param {object} [parameters.filters] - Filters used to refine search
-   * @param {string} [parameters.sortBy='relevance'] - The sorting method
-   * @param {string} [parameters.sortOrder='descending'] - The sort order for search results
+   * @param {string} [parameters.sortBy='relevance'] - The sort method for results
+   * @param {string} [parameters.sortOrder='descending'] - The sort order for results
    * @returns {Promise}
    * @see https://docs.constructor.io/rest-api.html#search
    */


### PR DESCRIPTION
✅  All tests pass

- Add ability to provide filters to `getRecommendations`, which is required for the filtered items strategy.