### PR TITLE
[CH 11952] Expose Purchase Event Helper Functions

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -11,7 +11,6 @@ const cloneDeep = require('lodash.clonedeep');
 const store = require('../../../test/utils/store');
 const ConstructorIO = require('../../../test/constructorio');
 const helpers = require('../../mocha.helpers');
-const { addOrderIdRecord } = require('../../../src/utils/helpers');
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -1752,7 +1751,7 @@ describe('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackPurchase', () => {
+  describe.only('trackPurchase', () => {
     const requiredParameters = {
       items: [
         {
@@ -2098,15 +2097,16 @@ describe('ConstructorIO - Tracker', () => {
     });
 
     it('Should not send a purchase event if the order has been tracked already', (done) => {
-      const { tracker } = new ConstructorIO({
+      const constructorio = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
         ...requestQueueOptions,
       });
+      const { tracker } = constructorio;
 
       tracker.on('success', eventSpy);
 
-      addOrderIdRecord('848291039');
+      constructorio.Tracker.addOrderIdRecord('848291039');
 
       expect(tracker.trackPurchase(Object.assign(requiredParameters, {
         ...optionalParameters,
@@ -2125,16 +2125,17 @@ describe('ConstructorIO - Tracker', () => {
     });
 
     it('Should send a purchase event if the order has not been tracked yet', (done) => {
-      const { tracker } = new ConstructorIO({
+      const constructorio = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
         ...requestQueueOptions,
       });
+      const { tracker } = constructorio;
 
       tracker.on('success', eventSpy);
 
-      addOrderIdRecord('239402919');
-      addOrderIdRecord('482039192');
+      constructorio.Tracker.addOrderIdRecord('239402919');
+      constructorio.Tracker.addOrderIdRecord('482039192');
 
       expect(tracker.trackPurchase(Object.assign(requiredParameters, {
         ...optionalParameters,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1751,7 +1751,7 @@ describe('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackPurchase', () => {
+  describe('trackPurchase', () => {
     const requiredParameters = {
       items: [
         {
@@ -2097,16 +2097,15 @@ describe('ConstructorIO - Tracker', () => {
     });
 
     it('Should not send a purchase event if the order has been tracked already', (done) => {
-      const constructorio = new ConstructorIO({
+      const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
         ...requestQueueOptions,
       });
-      const { tracker } = constructorio;
 
       tracker.on('success', eventSpy);
 
-      constructorio.Tracker.addOrderIdRecord('848291039');
+      tracker.addOrderIdRecord('848291039');
 
       expect(tracker.trackPurchase(Object.assign(requiredParameters, {
         ...optionalParameters,
@@ -2125,17 +2124,16 @@ describe('ConstructorIO - Tracker', () => {
     });
 
     it('Should send a purchase event if the order has not been tracked yet', (done) => {
-      const constructorio = new ConstructorIO({
+      const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
         ...requestQueueOptions,
       });
-      const { tracker } = constructorio;
 
       tracker.on('success', eventSpy);
 
-      constructorio.Tracker.addOrderIdRecord('239402919');
-      constructorio.Tracker.addOrderIdRecord('482039192');
+      tracker.addOrderIdRecord('239402919');
+      tracker.addOrderIdRecord('482039192');
 
       expect(tracker.trackPurchase(Object.assign(requiredParameters, {
         ...optionalParameters,

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -418,11 +418,11 @@ class Tracker {
 
       if (order_id) {
         // Don't send another purchase event if we have already tracked the order
-        if (Tracker.hasOrderIdRecord(order_id)) {
+        if (this.hasOrderIdRecord(order_id)) {
           return false;
         }
 
-        Tracker.addOrderIdRecord(order_id);
+        this.addOrderIdRecord(order_id);
 
         // Add order_id to the tracking params
         bodyParams.order_id = order_id;
@@ -864,7 +864,7 @@ class Tracker {
   /**
    * Expose helper function to add order id to storage
    */
-  static addOrderIdRecord(orderId) {
+  addOrderIdRecord(orderId) { /* eslint-disable-line class-methods-use-this */
     let purchaseEventStorage = JSON.parse(store.session.get(purchaseEventStorageKey));
     const orderIdHash = CRC32.str(orderId.toString());
 
@@ -891,7 +891,7 @@ class Tracker {
   /**
    * Expose helper function to check existence of order id in storage
    */
-  static hasOrderIdRecord(orderId) {
+  hasOrderIdRecord(orderId) { /* eslint-disable-line class-methods-use-this */
     const purchaseEventStorage = JSON.parse(store.session.get(purchaseEventStorageKey));
     const orderIdHash = CRC32.str(orderId.toString());
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -856,6 +856,20 @@ class Tracker {
 
     return true;
   }
+
+  /**
+   * Expose helper function to add order id to storage (used in other clients/repos)
+   */
+  static addOrderIdRecord(order_id) {
+    helpers.addOrderIdRecord(order_id);
+  }
+
+  /**
+   * Expose helper function to check existence of order id in storage (used in other clients/repos)
+   */
+  static hasOrderIdRecord(order_id) {
+    return helpers.hasOrderIdRecord(order_id);
+  }
 }
 
 module.exports = Tracker;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -858,14 +858,14 @@ class Tracker {
   }
 
   /**
-   * Expose helper function to add order id to storage (used in other clients/repos)
+   * Expose helper function to add order id to storage
    */
   static addOrderIdRecord(order_id) {
     helpers.addOrderIdRecord(order_id);
   }
 
   /**
-   * Expose helper function to check existence of order id in storage (used in other clients/repos)
+   * Expose helper function to check existence of order id in storage
    */
   static hasOrderIdRecord(order_id) {
     return helpers.hasOrderIdRecord(order_id);

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -1,9 +1,5 @@
 /* eslint-disable no-param-reassign */
 const qs = require('qs');
-const CRC32 = require('crc-32');
-const store = require('./store');
-
-const purchaseEventStorageKey = '_constructorio_purchase_order_ids';
 
 const utils = {
   ourEncodeURIComponent: (str) => {
@@ -77,41 +73,6 @@ const utils = {
     }
 
     return {};
-  },
-
-  hasOrderIdRecord(orderId) {
-    const purchaseEventStorage = JSON.parse(store.session.get(purchaseEventStorageKey));
-    const orderIdHash = CRC32.str(orderId.toString());
-
-    if (purchaseEventStorage && purchaseEventStorage[orderIdHash]) {
-      return true;
-    }
-
-    return null;
-  },
-
-  addOrderIdRecord(orderId) {
-    let purchaseEventStorage = JSON.parse(store.session.get(purchaseEventStorageKey));
-    const orderIdHash = CRC32.str(orderId.toString());
-
-    if (purchaseEventStorage) {
-
-      // If the order already exists, do nothing
-      if (purchaseEventStorage[orderIdHash]) {
-        return;
-      }
-
-      purchaseEventStorage[orderIdHash] = true;
-    } else {
-
-      // Create a new object map for the order ids
-      purchaseEventStorage = {
-        [orderIdHash]: true,
-      };
-    }
-
-    // Push the order id map into session storage
-    store.session.set(purchaseEventStorageKey, JSON.stringify(purchaseEventStorage));
   },
 };
 


### PR DESCRIPTION
#### Updates:
* Expose helper functions for checking/adding order ids in the storage
* Will be class level methods (i.e. usage `Tracker.addOrderIdRecord` and `Tracker.hasOrderIdRecord`)
* Doesn't get built into the docs 👍 