### PR TITLE
[CSL 8] Add Conversion Types to Tracking

### DIFF
--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -37,7 +37,6 @@ describe('ConstructorIO - Search', () => {
   describe('getSearchResults', () => {
     const query = 'drill';
     const section = 'Products';
-    const collectionId = 'test';
 
     it('Should return a response with a valid query, and section', (done) => {
       const { search } = new ConstructorIO({
@@ -292,24 +291,6 @@ describe('ConstructorIO - Search', () => {
       });
     });
 
-    it('Should return a response from collection with a valid query and collection id', (done) => {
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
-
-      search.getSearchResults(query, {
-        section,
-        collectionId,
-      }).then((res) => {
-        expect(res).to.have.property('request').to.be.an('object');
-        expect(res).to.have.property('response').to.be.an('object');
-        expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.response).to.have.property('results').to.be.an('array');
-        res.response.results.forEach((result) => {
-          expect(result).to.have.property('result_id').to.be.a('string').to.equal(res.result_id);
-        });
-        done();
-      });
-    });
-
     it('Should emit an event with response data', (done) => {
       const { search } = new ConstructorIO({
         apiKey: testApiKey,
@@ -402,16 +383,6 @@ describe('ConstructorIO - Search', () => {
       const { search } = new ConstructorIO({ apiKey: testApiKey });
 
       return expect(search.getSearchResults(query, { section: 123 })).to.eventually.be.rejected;
-    });
-
-    it('Should be rejected when invalid collection id parameter is provided', () => {
-      const { search } = new ConstructorIO({ apiKey: testApiKey });
-      const searchParams = {
-        section,
-        collectionId: 123,
-      };
-
-      return expect(search.getSearchResults(query, searchParams)).to.eventually.be.rejected;
     });
 
     it('Should be rejected when invalid apiKey is provided', () => {

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1775,7 +1775,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(null, requiredParameters)).to.equal(true);
     });
 
-    it('should respond with a valid response if `is_custom_type` is true, `display_name` is provided, and no `type` is specified', (done) => {
+    it('should respond with a valid response if is_custom_type is true, display_name is provided, and no type is specified', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1808,7 +1808,7 @@ describe('ConstructorIO - Tracker', () => {
       }, waitInterval);
     });
 
-    it('should respond with an error if `is_custom_type` is true, `type` is provided, and no `display_name` is specified', (done) => {
+    it('should respond with an error if is_custom_type is true, type is provided, and no display_name is specified', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1500,7 +1500,7 @@ describe('ConstructorIO - Tracker', () => {
   describe('trackConversion', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
-      customer_id: 'customer-id',
+      item_id: 'customer-id',
       revenue: 123,
       section: 'Products',
     };
@@ -1534,7 +1534,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
@@ -1572,7 +1572,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
@@ -1836,6 +1836,52 @@ describe('ConstructorIO - Tracker', () => {
         expect(eventSpy).to.have.been.called;
         expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('Conversion type must be one of add_to_wishlist, add_to_cart, like, message, make_offer, read. If you wish to use custom conversion types, please set is_custom_type to true and specify a display_name.');
+
+        done();
+      }, waitInterval);
+    });
+
+    it('should support v1 endpoint arguments', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      const parameters = {
+        customer_id: 'customer-id',
+        name: 'name',
+        section: 'Products',
+        revenue: 123,
+      };
+
+      tracker.on('success', eventSpy);
+
+      expect(tracker.trackConversion(term, parameters)).to.equal(true);
+
+      setTimeout(() => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('key');
+        expect(requestParams).to.have.property('i');
+        expect(requestParams).to.have.property('s');
+        expect(requestParams).to.have.property('c').to.equal(clientVersion);
+        expect(requestParams).to.have.property('_dt');
+        expect(requestParams).to.have.property('item_id').to.equal(parameters.customer_id);
+        expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
+        expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
+        expect(requestParams).to.have.property('section').to.equal(parameters.section);
+        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
       }, waitInterval);

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1506,8 +1506,8 @@ describe('ConstructorIO - Tracker', () => {
     };
 
     const optionalParameters = {
-      variation_id: 'variation-id',
       item_name: 'item_name',
+      variation_id: 'variation-id',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
@@ -1528,7 +1528,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(queryParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
+        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');
@@ -1566,8 +1566,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(queryParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
-        expect(queryParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
+        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');
@@ -1576,6 +1575,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
         expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
@@ -1835,7 +1835,7 @@ describe('ConstructorIO - Tracker', () => {
         // Response
         expect(eventSpy).to.have.been.called;
         expect(responseParams).to.have.property('method').to.equal('POST');
-        expect(responseParams).to.have.property('message').to.equal('Conversion type must be one of add_to_wishlist, add_to_cart, like, message, make_offer, read, custom. If you wish to use custom conversion types, please set is_custom_type to true and specify a display_name.');
+        expect(responseParams).to.have.property('message').to.equal('Conversion type must be one of add_to_wishlist, add_to_cart, like, message, make_offer, read. If you wish to use custom conversion types, please set is_custom_type to true and specify a display_name.');
 
         done();
       }, waitInterval);
@@ -2175,10 +2175,6 @@ describe('ConstructorIO - Tracker', () => {
         items: [
           {
             item_id: 'bad-item-id-10',
-            variation_id: '456',
-          },
-          {
-            item_id: 'bad-item-id-11',
           },
         ],
       })).to.equal(true);
@@ -2194,6 +2190,42 @@ describe('ConstructorIO - Tracker', () => {
         expect(eventSpy).to.have.been.called;
         expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.contain('There is no item with item_id="bad-item-id-10".');
+
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with an error if beacon=true is not in the request and a non-existent item_id/variation_id is provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+        beaconMode: false,
+      });
+
+      tracker.on('error', eventSpy);
+
+      expect(tracker.trackPurchase({
+        ...requiredParameters,
+        items: [
+          {
+            item_id: 'bad-item-id-10',
+            variation_id: '456',
+          },
+        ],
+      })).to.equal(true);
+
+      setTimeout(() => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(requestParams).to.not.have.property('beacon');
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.contain('There is no variation item with variation_id="456".');
 
         done();
       }, waitInterval);

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1497,7 +1497,7 @@ describe('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe.only('trackConversion', () => {
+  describe('trackConversion', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       customer_id: 'customer-id',

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1522,11 +1522,13 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
         const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
         expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');
@@ -1558,11 +1560,14 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, Object.assign({}, requiredParameters, optionalParameters))).to.equal(true);
 
       setTimeout(() => {
+        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
         const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
         expect(fetchSpy).to.have.been.called;
+        expect(queryParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
+        expect(queryParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -12,7 +12,6 @@ const store = require('../../../test/utils/store');
 const ConstructorIO = require('../../../test/constructorio');
 const helpers = require('../../mocha.helpers');
 const { addOrderIdRecord } = require('../../../src/utils/helpers');
-const { expect } = require('chai');
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -12,6 +12,7 @@ const store = require('../../../test/utils/store');
 const ConstructorIO = require('../../../test/constructorio');
 const helpers = require('../../mocha.helpers');
 const { addOrderIdRecord } = require('../../../src/utils/helpers');
+const { expect } = require('chai');
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -1497,18 +1498,17 @@ describe('ConstructorIO - Tracker', () => {
     });
   });
 
-  describe('trackConversion', () => {
+  describe.only('trackConversion', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
-      name: 'name',
       customer_id: 'customer-id',
-      result_id: 'result-id',
       revenue: 123,
       section: 'Products',
     };
 
     const optionalParameters = {
       variation_id: 'variation-id',
+      item_name: 'item_name',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
@@ -1523,7 +1523,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1533,16 +1533,14 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
-        expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1561,7 +1559,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, Object.assign({}, requiredParameters, optionalParameters))).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1571,9 +1569,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
-        expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.customer_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
@@ -1581,7 +1577,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1603,7 +1599,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, clonedParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1611,7 +1607,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1632,7 +1628,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1640,7 +1636,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1661,7 +1657,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1669,7 +1665,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1690,7 +1686,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1698,7 +1694,71 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when term, required parameters and conversion type are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_wishlist',
+      });
+
+      tracker.on('success', eventSpy);
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      }, waitInterval);
+    });
+
+    it('Should respond with a valid response when term, required parameters and custom conversion type are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_loves',
+        display_name: 'Add To Loves List',
+        is_custom_type: true,
+      });
+
+      tracker.on('success', eventSpy);
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.have.property('display_name').to.equal(fullParameters.display_name);
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1709,6 +1769,72 @@ describe('ConstructorIO - Tracker', () => {
       const { tracker } = new ConstructorIO({ apiKey: testApiKey });
 
       expect(tracker.trackConversion(null, requiredParameters)).to.equal(true);
+    });
+
+    it('should respond with a valid response if `is_custom_type` is true, `display_name` is provided, and no `type` is specified', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        display_name: 'Add To Loves List',
+        is_custom_type: true,
+      });
+
+      tracker.on('success', eventSpy);
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(requestParams).to.have.property('display_name').to.equal(fullParameters.display_name);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.not.have.property('type');
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      }, waitInterval);
+    });
+
+    it('should respond with an error if `is_custom_type` is true, `type` is provided, and no `display_name` is specified', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const fullParameters = Object.assign({}, requiredParameters, {
+        type: 'add_to_loves',
+        is_custom_type: true,
+      });
+
+      tracker.on('error', eventSpy);
+
+      expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+
+      setTimeout(() => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
+
+        // Request
+        expect(requestParams).to.have.property('type').to.equal(fullParameters.type);
+        expect(requestParams).to.have.property('is_custom_type').to.equal(fullParameters.is_custom_type);
+        expect(requestParams).to.not.have.property('display_name');
+
+        // Response
+        expect(eventSpy).to.have.been.called;
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('Conversion type must be one of add_to_wishlist, add_to_cart, like, message, make_offer, read, custom. If you wish to use custom conversion types, please set is_custom_type to true and specify a display_name.');
+
+        done();
+      }, waitInterval);
     });
 
     it('Should throw an error when invalid parameters are provided', () => {
@@ -1736,7 +1862,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1745,7 +1871,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();
@@ -1765,7 +1891,7 @@ describe('ConstructorIO - Tracker', () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
 
       setTimeout(() => {
-        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
         const responseParams = helpers.extractResponseParamsFromListener(eventSpy);
 
         // Request
@@ -1774,7 +1900,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Response
         expect(eventSpy).to.have.been.called;
-        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('method').to.equal('POST');
         expect(responseParams).to.have.property('message').to.equal('ok');
 
         done();

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -46,7 +46,7 @@ function createSearchUrl(query, parameters, options) {
   }
 
   if (parameters) {
-    const { page, resultsPerPage, filters, sortBy, sortOrder, section, collectionId, fmtOptions } = parameters;
+    const { page, resultsPerPage, filters, sortBy, sortOrder, section, fmtOptions } = parameters;
 
     // Pull page from parameters
     if (!helpers.isNil(page)) {

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -78,11 +78,6 @@ function createSearchUrl(query, parameters, options) {
       queryParams.section = section;
     }
 
-    // Pull collection id from parameters
-    if (collectionId) {
-      queryParams.collection_id = collectionId;
-    }
-
     // Pull format options from parameters
     if (fmtOptions) {
       queryParams.fmt_options = fmtOptions;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -344,12 +344,16 @@ class Tracker {
    * @function trackConversion
    * @param {string} term - Search results query term
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} parameters.name - Identifier
    * @param {string} parameters.customer_id - Customer id
    * @param {string} parameters.revenue - Revenue
+   * @param {string} [parameters.item_name] - Identifier
    * @param {string} [parameters.variation_id] - Variation id
-   * @param {string} [parameters.section] - Autocomplete section
+   * @param {string} [parameters.type] - Conversion Type (default: add_to_cart)
+   * @param {boolean} [parameters.is_custom_type] - Specify if it's a custom conversion type
+   * @param {string} [parameters.display_name] - Display name for the custom conversion type
+   * (Required if `is_custom_type` is true)
    * @param {string} [parameters.result_id] - Result id
+   * @param {string} [parameters.section] - Autocomplete section
    * @returns {(true|Error)}
    */
   trackConversion(term, parameters) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -348,7 +348,7 @@ class Tracker {
    * @param {string} parameters.revenue - Revenue
    * @param {string} [parameters.item_name] - Identifier
    * @param {string} [parameters.variation_id] - Variation id
-   * @param {string} [parameters.type] - Conversion Type (default: add_to_cart)
+   * @param {string} [parameters.type] - Conversion type (default: add_to_cart)
    * @param {boolean} [parameters.is_custom_type] - Specify if it's a custom conversion type
    * @param {string} [parameters.display_name] - Display name for the custom conversion type
    * (Required if `is_custom_type` is true)

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -348,10 +348,9 @@ class Tracker {
    * @param {string} parameters.revenue - Revenue
    * @param {string} [parameters.item_name] - Identifier
    * @param {string} [parameters.variation_id] - Variation id
-   * @param {string} [parameters.type] - Conversion type (default: add_to_cart)
-   * @param {boolean} [parameters.is_custom_type] - Specify if it's a custom conversion type
+   * @param {string} [parameters.type='add_to_cart'] - Conversion type
+   * @param {boolean} [parameters.is_custom_type] - Specify if type is custom conversion type
    * @param {string} [parameters.display_name] - Display name for the custom conversion type
-   * (Required if `is_custom_type` is true)
    * @param {string} [parameters.result_id] - Result id
    * @param {string} [parameters.section] - Autocomplete section
    * @returns {(true|Error)}

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -375,19 +375,14 @@ class Tracker {
         is_custom_type,
       } = parameters;
 
-      // Always send item_name in the request URL if it exists
-      if (item_name) {
-        queryParams.item_name = item_name;
-      }
-
-      // Only take one of item_id, customer_id, or item_name
+      // Only take one of item_id or customer_id
       if (item_id) {
-        queryParams.item_id = item_id;
         bodyParams.item_id = item_id;
       } else if (customer_id) {
-        queryParams.item_id = customer_id;
         bodyParams.item_id = customer_id;
-      } else if (item_name) {
+      }
+
+      if (item_name) {
         bodyParams.item_name = item_name;
       }
 
@@ -400,6 +395,7 @@ class Tracker {
       }
 
       if (section) {
+        queryParams.section = section;
         bodyParams.section = section;
       }
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -363,6 +363,7 @@ class Tracker {
       const queryParams = {};
       const bodyParams = {};
       const {
+        name,
         item_name,
         item_id,
         customer_id,
@@ -383,6 +384,8 @@ class Tracker {
 
       if (item_name) {
         bodyParams.item_name = item_name;
+      } else if (name) {
+        bodyParams.item_name = name;
       }
 
       if (variation_id) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -367,7 +367,7 @@ class Tracker {
         section = 'Products',
         display_name,
         type,
-        is_custom_type = false,
+        is_custom_type,
       } = parameters;
 
       // Only take one of item_id, customer_id, or item_name

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -361,6 +361,7 @@ class Tracker {
     if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
       const searchTerm = helpers.ourEncodeURIComponent(term) || 'TERM_UNKNOWN';
       const requestPath = `${this.options.serviceUrl}/v2/behavioral_action/conversion?`;
+      const queryParams = {};
       const bodyParams = {};
       const {
         item_name,
@@ -374,10 +375,17 @@ class Tracker {
         is_custom_type,
       } = parameters;
 
+      // Always send item_name in the request URL if it exists
+      if (item_name) {
+        queryParams.item_name = item_name;
+      }
+
       // Only take one of item_id, customer_id, or item_name
       if (item_id) {
+        queryParams.item_id = item_id;
         bodyParams.item_id = item_id;
       } else if (customer_id) {
+        queryParams.item_id = customer_id;
         bodyParams.item_id = customer_id;
       } else if (item_name) {
         bodyParams.item_name = item_name;
@@ -411,7 +419,7 @@ class Tracker {
         bodyParams.display_name = display_name;
       }
 
-      const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;
+      const requestURL = `${requestPath}${applyParamsAsString(queryParams, this.options)}`;
       const requestMethod = 'POST';
       const requestBody = applyParams(bodyParams, { ...this.options, requestMethod });
 


### PR DESCRIPTION
#### Updates:
* Update trackConversion to use v2 endpoint
* Add support for converstion types
* Add/Update tests