### PR TITLE
Better encoding handling

### DIFF
--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -8,7 +8,7 @@ const purchaseEventStorageKey = '_constructorio_purchase_order_ids';
 const utils = {
   ourEncodeURIComponent: (str) => {
     if (str) {
-      const parsedStrObj = qs.parse(`s=${str.replace(/&/g, '%26')}`);
+      const parsedStrObj = qs.parse(`s=${encodeURIComponent(str)}`);
 
       parsedStrObj.s = parsedStrObj.s.replace(/\s/g, ' ');
 


### PR DESCRIPTION
#### Updates:
* Fixes an issue where there are brackets or other special characters used in the query params
* This was specifically affecting Sephora
    * https://www.sephora.com/shop/moisturizer-skincare?ref=filters[Brand]=Algenist,filters[Ingredient%20Preferences]=Vegan
    * Going to the URL above, you will see that when sending the browse results load event, it errors out on our `ourEncodeURIComponent` because it's origin_referrers that have brackets in it incorrectly.
    * Calling `encodeURIComponent` before passing it to qs.parse resolves this issue and should also encode any other special characters
    
<img width="1334" alt="Screen Shot 2021-05-11 at 1 20 33 PM" src="https://user-images.githubusercontent.com/7194266/117879331-b302b800-b25b-11eb-8714-aa2fc5f7ba64.png">
