### PR TITLE
[CSL-215] Java SDK : Remove API key and token

### DIFF
--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -35,7 +35,7 @@ describe('ConstructorIO - Autocomplete', () => {
   });
 
   describe('getAutocompleteResults', () => {
-    const query = 'drill';
+    const query = 'item';
 
     it('Should return a response with a valid query', (done) => {
       const { autocomplete } = new ConstructorIO({

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -35,7 +35,7 @@ describe('ConstructorIO - Search', () => {
   });
 
   describe('getSearchResults', () => {
-    const query = 'drill';
+    const query = 'item';
     const section = 'Products';
 
     it('Should return a response with a valid query, and section', (done) => {


### PR DESCRIPTION
The changes in the Java tests and the catalog CSV files we use broke two tests in this repo. This PR fixes them and uses the same story for reference