### PR TITLE
Remove result_id requirement for trackSearchSubmit.

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -654,10 +654,7 @@ describe('ConstructorIO - Tracker', () => {
 
   describe('trackSearchSubmit', () => {
     const term = 'Where The Wild Things Are';
-    const requiredParameters = {
-      original_query: 'original-query',
-      result_id: 'result-id',
-    };
+    const requiredParameters = { original_query: 'original-query' };
     const optionalParameters = {
       group_id: 'group-id',
       display_name: 'display-name',
@@ -681,7 +678,6 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -200,7 +200,6 @@ class Tracker {
    * @param {string} term - Term of submitted autocomplete event
    * @param {object} parameters - Additional parameters to be sent with request
    * @param {string} parameters.original_query - The current autocomplete search query
-   * @param {string} parameters.result_id - Customer ID of the selected autocomplete item
    * @param {string} [parameters.group_id] - Group identifier of selected item
    * @param {string} [parameters.display_name] - Display name of group of selected item
    * @returns {(true|Error)}
@@ -213,7 +212,7 @@ class Tracker {
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
         const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/search?`;
         const queryParams = {};
-        const { original_query, result_id, group_id, display_name } = parameters;
+        const { original_query, group_id, display_name } = parameters;
 
         if (original_query) {
           queryParams.original_query = original_query;
@@ -224,10 +223,6 @@ class Tracker {
             group_id,
             display_name,
           };
-        }
-
-        if (result_id) {
-          queryParams.result_id = result_id;
         }
 
         this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);


### PR DESCRIPTION
`result_id` isn't required for `trackSearchSubmit` - remove.