### PR TITLE
[CSL-491] Concept consistency improvements

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -870,11 +870,12 @@ describe('ConstructorIO - Tracker', () => {
 
   describe('trackSearchResultsLoaded', () => {
     const term = 'Cat in the Hat';
-    const requiredParameters = {
-      num_results: 1337,
-    };
+    const requiredParameters = { num_results: 1337 };
     const optionalParameters = { item_ids: [1, 2, 3] };
-    const legacyOptionalParameters = { customer_ids: [1, 2, 3] };
+    const legacyParameters = {
+      ...requiredParameters,
+      customer_ids: [1, 2, 3],
+    };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
@@ -1010,7 +1011,7 @@ describe('ConstructorIO - Tracker', () => {
         .to.equal(true);
     });
 
-    it('Should respond with a valid response when term, required and optional legacy parameters are provided', (done) => {
+    it('Should respond with a valid response when term and legacy parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1022,7 +1023,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('customer_ids').to.equal(legacyOptionalParameters.customer_ids.join(','));
+        expect(requestParams).to.have.property('customer_ids').to.equal(legacyParameters.customer_ids.join(','));
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1032,8 +1033,7 @@ describe('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultsLoaded(term, Object.assign(requiredParameters, legacyOptionalParameters)))
-        .to.equal(true);
+      expect(tracker.trackSearchResultsLoaded(term, legacyParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when term, and zero value num_results parameter are provided', (done) => {
@@ -1139,10 +1139,11 @@ describe('ConstructorIO - Tracker', () => {
   describe('trackSearchResultClick', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
-      name: 'name',
+      item_name: 'name',
       item_id: 'customer-id',
     };
-    const requiredLegacyParameters = {
+    const legacyParameters = {
+      ...requiredParameters,
       name: 'name',
       customer_id: 'customer-id',
     };
@@ -1168,7 +1169,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
+        expect(requestParams).to.have.property('name').to.equal(requiredParameters.item_name);
         expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
@@ -1315,7 +1316,7 @@ describe('ConstructorIO - Tracker', () => {
       ))).to.equal(true);
     });
 
-    it('Should respond with a valid response when term and required legacy parameters are provided', (done) => {
+    it('Should respond with a valid response when term and legacy parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1327,7 +1328,8 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('customer_id').to.equal(requiredLegacyParameters.customer_id);
+        expect(requestParams).to.have.property('customer_id').to.equal(legacyParameters.customer_id);
+        expect(requestParams).to.have.property('name').to.equal(legacyParameters.name);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1336,7 +1338,7 @@ describe('ConstructorIO - Tracker', () => {
         done();
       });
 
-      expect(tracker.trackSearchResultClick(term, requiredLegacyParameters)).to.equal(true);
+      expect(tracker.trackSearchResultClick(term, legacyParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {
@@ -1419,12 +1421,16 @@ describe('ConstructorIO - Tracker', () => {
     const requiredParameters = {
       item_id: 'customer-id',
       revenue: 123,
-      section: 'Products',
     };
-
     const optionalParameters = {
       item_name: 'item_name',
       variation_id: 'variation-id',
+      section: 'Products',
+    };
+    const legacyParameters = {
+      customer_id: 'customer-id',
+      revenue: 123,
+      name: 'item_name',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
@@ -1435,12 +1441,10 @@ describe('ConstructorIO - Tracker', () => {
       });
 
       tracker.on('success', (responseParams) => {
-        const queryParams = helpers.extractUrlParamsFromFetch(fetchSpy);
         const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');
@@ -1448,7 +1452,6 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
-        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
@@ -1474,7 +1477,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(queryParams).to.have.property('section').to.equal(requiredParameters.section);
+        expect(queryParams).to.have.property('section').to.equal(optionalParameters.section);
         expect(requestParams).to.have.property('key');
         expect(requestParams).to.have.property('i');
         expect(requestParams).to.have.property('s');
@@ -1482,9 +1485,9 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
-        expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
         expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.item_name);
         expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
+        expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
@@ -1658,6 +1661,31 @@ describe('ConstructorIO - Tracker', () => {
       });
 
       expect(tracker.trackConversion(term, fullParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term and legacy parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('item_id').to.equal(legacyParameters.customer_id);
+        expect(requestParams).to.have.property('item_name').to.equal(legacyParameters.name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackConversion(term, legacyParameters)).to.equal(true);
     });
 
     it('Should respond with a valid response when no term is provided, but parameters are', () => {

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -873,9 +873,8 @@ describe('ConstructorIO - Tracker', () => {
     const requiredParameters = {
       num_results: 1337,
     };
-    const optionalParameters = {
-      customer_ids: [1, 2, 3],
-    };
+    const optionalParameters = { item_ids: [1, 2, 3] };
+    const legacyOptionalParameters = { customer_ids: [1, 2, 3] };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
@@ -997,7 +996,7 @@ describe('ConstructorIO - Tracker', () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('customer_ids').to.equal(optionalParameters.customer_ids.join(','));
+        expect(requestParams).to.have.property('customer_ids').to.equal(optionalParameters.item_ids.join(','));
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1008,6 +1007,32 @@ describe('ConstructorIO - Tracker', () => {
       });
 
       expect(tracker.trackSearchResultsLoaded(term, Object.assign(requiredParameters, optionalParameters)))
+        .to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required and optional legacy parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('customer_ids').to.equal(legacyOptionalParameters.customer_ids.join(','));
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultsLoaded(term, Object.assign(requiredParameters, legacyOptionalParameters)))
         .to.equal(true);
     });
 
@@ -1115,11 +1140,18 @@ describe('ConstructorIO - Tracker', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       name: 'name',
+      item_id: 'customer-id',
+    };
+    const requiredLegacyParameters = {
+      name: 'name',
       customer_id: 'customer-id',
+    };
+    const optionalParameters = {
+      variation_id: 'foobar',
       result_id: 'result-id',
     };
 
-    it('Should respond with a valid response when term and required parmeters are provided', (done) => {
+    it('Should respond with a valid response when term and required parameters are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1137,8 +1169,7 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('name').to.equal(requiredParameters.name);
-        expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.customer_id);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
+        expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.item_id);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response
@@ -1254,6 +1285,58 @@ describe('ConstructorIO - Tracker', () => {
         ...requiredParameters,
         variation_id: 'variation-id',
       })).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term, required parameters and optional parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.result_id);
+        expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variation_id);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, Object.assign(
+        requiredParameters,
+        optionalParameters,
+      ))).to.equal(true);
+    });
+
+    it('Should respond with a valid response when term and required legacy parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('customer_id').to.equal(requiredLegacyParameters.customer_id);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('GET');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackSearchResultClick(term, requiredLegacyParameters)).to.equal(true);
     });
 
     it('Should throw an error when invalid term is provided', () => {

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -429,7 +429,6 @@ describe('ConstructorIO - Tracker', () => {
     const term = 'Where The Wild Things Are';
     const requiredParameters = {
       original_query: 'original-query',
-      result_id: 'result-id',
       section: 'Search Suggestions',
     };
     const optionalParameters = {
@@ -457,7 +456,6 @@ describe('ConstructorIO - Tracker', () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.original_query);
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
-        expect(requestParams).to.have.property('result_id').to.equal(requiredParameters.result_id);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
 
         // Response

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -129,7 +129,6 @@ class Tracker {
    * @param {string} term - Term of selected autocomplete item
    * @param {object} parameters - Additional parameters to be sent with request
    * @param {string} parameters.original_query - The current autocomplete search query
-   * @param {string} parameters.result_id - Customer id of the selected autocomplete item
    * @param {string} parameters.section - Section the selected item resides within
    * @param {string} [parameters.tr] - Trigger used to select the item (click, etc.)
    * @param {string} [parameters.group_id] - Group identifier of selected item
@@ -146,7 +145,6 @@ class Tracker {
         const queryParams = {};
         const {
           original_query,
-          result_id,
           section,
           original_section,
           tr,
@@ -171,10 +169,6 @@ class Tracker {
             group_id,
             display_name,
           };
-        }
-
-        if (result_id) {
-          queryParams.result_id = result_id;
         }
 
         this.requests.queue(`${url}${applyParamsAsString(queryParams, this.options)}`);

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -242,7 +242,7 @@ class Tracker {
    * @param {string} term - Search results query term
    * @param {object} parameters - Additional parameters to be sent with request
    * @param {number} parameters.num_results - Number of search results in total
-   * @param {array} [parameters.customer_ids] - List of customer item id's returned from search
+   * @param {array} [parameters.item_ids] - List of product item unique identifiers in search results listing
    * @returns {(true|Error)}
    * @description User viewed a search product listing page
    */
@@ -253,13 +253,16 @@ class Tracker {
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
         const url = `${this.options.serviceUrl}/behavior?`;
         const queryParams = { action: 'search-results', term };
-        const { num_results, customer_ids } = parameters;
+        const { num_results, customer_ids, item_ids } = parameters;
 
         if (!helpers.isNil(num_results)) {
           queryParams.num_results = num_results;
         }
 
-        if (customer_ids && Array.isArray(customer_ids)) {
+        // Ensure support for both item_ids and customer_ids as parameters
+        if (item_ids && Array.isArray(item_ids)) {
+          queryParams.customer_ids = item_ids.join(',');
+        } else if (customer_ids && Array.isArray(customer_ids)) {
           queryParams.customer_ids = customer_ids.join(',');
         }
 
@@ -285,9 +288,10 @@ class Tracker {
    * @function trackSearchResultClick
    * @param {string} term - Search results query term
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} parameters.name - Identifier
-   * @param {string} parameters.customer_id - Customer id
-   * @param {string} [parameters.result_id] - Result id
+   * @param {string} parameters.name - Product item name
+   * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} [parameters.variation_id] - Product item variation unique identifier
+   * @param {string} [parameters.result_id] - Search result identifier (returned in response from Constructor)
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a search product listing page
    */
@@ -298,13 +302,16 @@ class Tracker {
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
         const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/click_through?`;
         const queryParams = {};
-        const { name, customer_id, variation_id, result_id } = parameters;
+        const { name, item_id, customer_id, variation_id, result_id } = parameters;
 
         if (name) {
           queryParams.name = name;
         }
 
-        if (customer_id) {
+        // Ensure support for both item_id and customer_id as parameters
+        if (item_id) {
+          queryParams.customer_id = item_id;
+        } else if (customer_id) {
           queryParams.customer_id = customer_id;
         }
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -288,7 +288,7 @@ class Tracker {
    * @function trackSearchResultClick
    * @param {string} term - Search results query term
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} parameters.name - Product item name
+   * @param {string} parameters.item_name - Product item name
    * @param {string} parameters.item_id - Product item unique identifier
    * @param {string} [parameters.variation_id] - Product item variation unique identifier
    * @param {string} [parameters.result_id] - Search result identifier (returned in response from Constructor)
@@ -302,9 +302,12 @@ class Tracker {
       if (parameters && typeof parameters === 'object' && !Array.isArray(parameters)) {
         const url = `${this.options.serviceUrl}/autocomplete/${helpers.ourEncodeURIComponent(term)}/click_through?`;
         const queryParams = {};
-        const { name, item_id, customer_id, variation_id, result_id } = parameters;
+        const { item_name, name, item_id, customer_id, variation_id, result_id } = parameters;
 
-        if (name) {
+        // Ensure support for both item_name and name as parameters
+        if (item_name) {
+          queryParams.name = item_name;
+        } else if (name) {
           queryParams.name = name;
         }
 
@@ -345,14 +348,14 @@ class Tracker {
    * @function trackConversion
    * @param {string} term - Search results query term
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} parameters.customer_id - Customer id
-   * @param {string} parameters.revenue - Revenue
-   * @param {string} [parameters.item_name] - Identifier
-   * @param {string} [parameters.variation_id] - Variation id
+   * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} parameters.revenue - Revenue (price) of product item
+   * @param {string} [parameters.item_name] - Product item name
+   * @param {string} [parameters.variation_id] - Product item variation unique identifier
    * @param {string} [parameters.type='add_to_cart'] - Conversion type
    * @param {boolean} [parameters.is_custom_type] - Specify if type is custom conversion type
    * @param {string} [parameters.display_name] - Display name for the custom conversion type
-   * @param {string} [parameters.result_id] - Result id
+   * @param {string} [parameters.result_id] - Result identifier (returned in response from Constructor)
    * @param {string} [parameters.section] - Autocomplete section
    * @returns {(true|Error)}
    * @description User performed an action indicating interest in an item (add to cart, add to wishlist, etc.)
@@ -377,13 +380,14 @@ class Tracker {
         is_custom_type,
       } = parameters;
 
-      // Only take one of item_id or customer_id
+      // Ensure support for both item_id and customer_id as parameters
       if (item_id) {
         bodyParams.item_id = item_id;
       } else if (customer_id) {
         bodyParams.item_id = customer_id;
       }
 
+      // Ensure support for both item_name and name as parameters
       if (item_name) {
         bodyParams.item_name = item_name;
       } else if (name) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -356,7 +356,7 @@ class Tracker {
    * @param {boolean} [parameters.is_custom_type] - Specify if type is custom conversion type
    * @param {string} [parameters.display_name] - Display name for the custom conversion type
    * @param {string} [parameters.result_id] - Result identifier (returned in response from Constructor)
-   * @param {string} [parameters.section] - Autocomplete section
+   * @param {string} [parameters.section] - Index section
    * @returns {(true|Error)}
    * @description User performed an action indicating interest in an item (add to cart, add to wishlist, etc.)
    */
@@ -447,10 +447,10 @@ class Tracker {
    *
    * @function trackPurchase
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {array} parameters.items - List of objects of customer items returned from browse
+   * @param {array} parameters.items - List of product item objects
    * @param {number} parameters.revenue - Revenue
-   * @param {string} [parameters.order_id] - Customer unique order identifier
-   * @param {string} [parameters.section] - Autocomplete section
+   * @param {string} [parameters.order_id] - Unique order identifier
+   * @param {string} [parameters.section] - Index section
    * @returns {(true|Error)}
    * @description User completed an order (usually fired on order confirmation page)
    */
@@ -512,13 +512,13 @@ class Tracker {
    *
    * @function trackRecommendationView
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {number} [parameters.result_count] - Number of results displayed
-   * @param {number} [parameters.result_page] - Page number of results
-   * @param {string} [parameters.result_id] - Result identifier
-   * @param {string} [parameters.section="Products"] - Results section
    * @param {string} parameters.url - Current page URL
    * @param {string} parameters.pod_id - Pod identifier
    * @param {number} parameters.num_results_viewed - Number of results viewed
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Recommendation result identifier (returned in response from Constructor)
+   * @param {string} [parameters.section="Products"] - Results section
    * @returns {(true|Error)}
    * @description User viewed a set of recommendations
    */
@@ -591,16 +591,16 @@ class Tracker {
    *
    * @function trackRecommendationClick
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} [parameters.variation_id] - Variation identifier
-   * @param {string} [parameters.section="Products"] - Results section
-   * @param {string} [parameters.result_id] - Result identifier
+   * @param {string} parameters.pod_id - Pod identifier
+   * @param {string} parameters.strategy_id - Strategy identifier
+   * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} [parameters.variation_id] - Product item variation unique identifier
+   * @param {string} [parameters.section="Products"] - Index section
+   * @param {string} [parameters.result_id] - Recommendation result identifier (returned in response from Constructor)
    * @param {number} [parameters.result_count] - Number of results displayed
    * @param {number} [parameters.result_page] - Page number of results
    * @param {number} [parameters.result_position_on_page] - Position of result on page
    * @param {number} [parameters.num_results_per_page] - Number of results on page
-   * @param {string} parameters.pod_id - Pod identifier
-   * @param {string} parameters.strategy_id - Strategy identifier
-   * @param {string} parameters.item_id - Identifier of clicked item
    * @returns {(true|Error)}
    * @description User clicked an item that appeared within a list of recommended results
    */
@@ -688,17 +688,17 @@ class Tracker {
    *
    * @function trackBrowseResultsLoaded
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} [parameters.section="Products"] - Results section
-   * @param {number} [parameters.result_count] - Number of results displayed
-   * @param {number} [parameters.result_page] - Page number of results
-   * @param {string} [parameters.result_id] - Result identifier
-   * @param {string} [parameters.selected_filters] -  Selected filters
-   * @param {string} [parameters.sort_order] - Sort order ('ascending' or 'descending')
-   * @param {string} [parameters.sort_by] - Sorting method
-   * @param {array} [parameters.items] - List of objects of customer items returned from browse
    * @param {string} parameters.url - Current page URL
    * @param {string} parameters.filter_name - Filter name
    * @param {string} parameters.filter_value - Filter value
+   * @param {string} [parameters.section="Products"] - Index section
+   * @param {number} [parameters.result_count] - Number of results displayed
+   * @param {number} [parameters.result_page] - Page number of results
+   * @param {string} [parameters.result_id] - Browse result identifier (returned in response from Constructor)
+   * @param {string} [parameters.selected_filters] -  Selected filters
+   * @param {string} [parameters.sort_order] - Sort order ('ascending' or 'descending')
+   * @param {string} [parameters.sort_by] - Sorting method
+   * @param {array} [parameters.items] - List of product item objects
    * @returns {(true|Error)}
    * @description User viewed a browse product listing page
    */
@@ -791,17 +791,17 @@ class Tracker {
    *
    * @function trackBrowseResultClick
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} [parameters.section="Products"] - Results section
-   * @param {string} [parameters.variation_id] - Variation ID of clicked item
-   * @param {string} [parameters.result_id] - Result identifier
+   * @param {string} parameters.filter_name - Filter name
+   * @param {string} parameters.filter_value - Filter value
+   * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} [parameters.section="Products"] - Index section
+   * @param {string} [parameters.variation_id] - Product item variation unique identifier
+   * @param {string} [parameters.result_id] - Browse result identifier (returned in response from Constructor)
    * @param {number} [parameters.result_count] - Number of results displayed
    * @param {number} [parameters.result_page] - Page number of results
    * @param {number} [parameters.result_position_on_page] - Position of clicked item
    * @param {number} [parameters.num_results_per_page] - Number of results shown
    * @param {string} [parameters.selected_filters] -  Selected filters
-   * @param {string} parameters.filter_name - Filter name
-   * @param {string} parameters.filter_value - Filter value
-   * @param {string} parameters.item_id - ID of clicked item
    * @returns {(true|Error)}
    * @description User clicked a result that appeared within a browse product listing page
    */
@@ -894,10 +894,10 @@ class Tracker {
    *
    * @function trackGenericResultClick
    * @param {object} parameters - Additional parameters to be sent with request
-   * @param {string} parameters.item_id - ID of clicked item
-   * @param {string} [parameters.item_name] - Name of clicked item
-   * @param {string} [parameters.variation_id] - Variation ID of clicked item
-   * @param {string} [parameters.section="Products"] - Results section
+   * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} [parameters.item_name] - Product item name
+   * @param {string} [parameters.variation_id] - Product item variation unique identifier
+   * @param {string} [parameters.section="Products"] - Index section
    * @returns {(true|Error)}
    * @description User clicked a result that appeared outside of the scope of search / browse / recommendations
    */


### PR DESCRIPTION
- Any method that used to accept `customer_id` will still do so, but is documented as `item_id` to be more consistent + tests
- Any method that used to accept `name` will still do so, but is documented as `item_name` to be more clear and consistent + tests
- More concise documentation of concepts globally across tracking module

This change does not introduce any breakage to existing implementations / previous versions. We'll need to port these changes to `constructorio-node` once approved.