### PR TITLE
[CSL-517] Research best SDK approach for React Native (and other DOM-less environments)

### DIFF
--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -94,6 +94,15 @@ describe('ConstructorIO', () => {
     expect(() => new ConstructorIO()).to.throw('API key is a required parameter of type string');
   });
 
+  it('Should not have client version set to indicate no DOM context', () => {
+    global.CLIENT_VERSION = null;
+
+    const instance = new ConstructorIO({ apiKey: validApiKey });
+
+    expect(instance).to.be.an('object');
+    expect(instance.options.version).to.not.include('-domless-');
+  });
+
   describe('setClientOptions', () => {
     it('Should update the client options with new API key', () => {
       const newAPIKey = 'newAPIKey';
@@ -335,7 +344,9 @@ describe('ConstructorIO - without DOM context', () => {
     })).to.throw('sessionId is a required user parameter of type number');
   });
 
-  it('Should have tracking events enabled enabled', () => {
+  it('Should have client version set to indicate no DOM context', () => {
+    global.CLIENT_VERSION = null;
+
     const instance = new ConstructorIO({
       apiKey: validApiKey,
       clientId,
@@ -343,6 +354,6 @@ describe('ConstructorIO - without DOM context', () => {
     });
 
     expect(instance).to.be.an('object');
-    expect(instance.options.sendTrackingEvents).to.be.true;
+    expect(instance.options.version).to.include('-domless-');
   });
 });

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -312,6 +312,14 @@ describe('ConstructorIO - without DOM context', () => {
     })).to.throw('clientId is a required user parameter of type string');
   });
 
+  it('Should throw an error if client identifier is invalid', () => {
+    expect(() => new ConstructorIO({
+      apiKey: validApiKey,
+      sessionId,
+      clientId: 123,
+    })).to.throw('clientId is a required user parameter of type string');
+  });
+
   it('Should throw an error if session identifier is not provided', () => {
     expect(() => new ConstructorIO({
       apiKey: validApiKey,
@@ -319,7 +327,15 @@ describe('ConstructorIO - without DOM context', () => {
     })).to.throw('sessionId is a required user parameter of type number');
   });
 
-  it('Should have event dispatching and tracking events disabled', () => {
+  it('Should throw an error if session identifier is invalid', () => {
+    expect(() => new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+      sessionId: 'aaa',
+    })).to.throw('sessionId is a required user parameter of type number');
+  });
+
+  it('Should have tracking events enabled enabled', () => {
     const instance = new ConstructorIO({
       apiKey: validApiKey,
       clientId,
@@ -327,9 +343,6 @@ describe('ConstructorIO - without DOM context', () => {
     });
 
     expect(instance).to.be.an('object');
-    expect(instance).to.have.property('options').to.be.an('object');
-    expect(instance.options).to.have.property('eventDispatcher').to.be.an('object');
-    expect(instance.options.eventDispatcher).to.have.property('enabled').to.be.false;
-    expect(instance.options.sendTrackingEvents).to.be.false;
+    expect(instance.options.sendTrackingEvents).to.be.true;
   });
 });

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -276,6 +276,9 @@ describe('ConstructorIO', () => {
 });
 
 describe('ConstructorIO - without DOM context', () => {
+  const clientId = '6c73138f-a87b-49f0-872d-63b00ed0e395';
+  const sessionId = 2;
+
   beforeEach(() => {
     global.CLIENT_VERSION = 'cio-mocha';
   });
@@ -284,8 +287,12 @@ describe('ConstructorIO - without DOM context', () => {
     delete global.CLIENT_VERSION;
   });
 
-  it('Should return an instance', () => {
-    const instance = new ConstructorIO({ apiKey: validApiKey });
+  it('Should return an instance if client and session identifiers are provided', () => {
+    const instance = new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+      sessionId,
+    });
 
     expect(instance).to.be.an('object');
     expect(instance).to.have.property('options').to.be.an('object');
@@ -298,17 +305,26 @@ describe('ConstructorIO - without DOM context', () => {
     expect(instance).to.have.property('tracker');
   });
 
-  it('Should have client and session identifiers not defined by default', () => {
-    const instance = new ConstructorIO({ apiKey: validApiKey });
+  it('Should throw an error if client identifier is not provided', () => {
+    expect(() => new ConstructorIO({
+      apiKey: validApiKey,
+      sessionId,
+    })).to.throw('clientId is a required user parameter of type string');
+  });
 
-    expect(instance).to.be.an('object');
-    expect(instance).to.have.property('options').to.be.an('object');
-    expect(instance.options).to.have.property('clientId').to.be.undefined;
-    expect(instance.options).to.have.property('sessionId').to.be.undefined;
+  it('Should throw an error if session identifier is not provided', () => {
+    expect(() => new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+    })).to.throw('sessionId is a required user parameter of type number');
   });
 
   it('Should have event dispatching and tracking events disabled', () => {
-    const instance = new ConstructorIO({ apiKey: validApiKey });
+    const instance = new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+      sessionId,
+    });
 
     expect(instance).to.be.an('object');
     expect(instance).to.have.property('options').to.be.an('object');

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -275,7 +275,7 @@ describe('ConstructorIO', () => {
   });
 });
 
-describe('ConstructorIO - without `window`', () => {
+describe('ConstructorIO - without DOM context', () => {
   beforeEach(() => {
     global.CLIENT_VERSION = 'cio-mocha';
   });

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -88,7 +88,9 @@ class ConstructorIO {
 
     // Disable event dispatcher and tracking events if `window` not available
     if (!helpers.hasWindow()) {
-      this.options.sendTrackingEvents = false;
+      if (window !== global) {
+        this.options.sendTrackingEvents = false;
+      }
 
       if (!this.options.eventDispatcher) {
         this.options.eventDispatcher = {};

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -67,6 +67,16 @@ class ConstructorIO {
     // Initialize ID session if DOM context is available
     if (helpers.canUseDOM()) {
       ({ session_id, client_id } = new ConstructorioID(idOptions || {}));
+    } else {
+      // Validate session ID is provided
+      if (!sessionId || typeof sessionId !== 'number') {
+        throw new Error('sessionId is a required user parameter of type number');
+      }
+
+      // Validate client ID is provided
+      if (!clientId || typeof clientId !== 'string') {
+        throw new Error('clientId is a required user parameter of type string');
+      }
     }
 
     this.options = {

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -39,6 +39,7 @@ class ConstructorIO {
    * @returns {class}
    */
   constructor(options = {}) {
+    const canUseDOM = helpers.canUseDOM();
     const {
       apiKey,
       version,
@@ -65,7 +66,7 @@ class ConstructorIO {
     let client_id;
 
     // Initialize ID session if DOM context is available
-    if (helpers.canUseDOM()) {
+    if (canUseDOM) {
       ({ session_id, client_id } = new ConstructorioID(idOptions || {}));
     } else {
       // Validate session ID is provided
@@ -81,7 +82,7 @@ class ConstructorIO {
 
     this.options = {
       apiKey,
-      version: version || global.CLIENT_VERSION || `ciojs-client-${packageVersion}`,
+      version: version || global.CLIENT_VERSION || `ciojs-client-${canUseDOM ? '' : 'domless-'}${packageVersion}`,
       serviceUrl: serviceUrl || 'https://ac.cnstrc.com',
       sessionId: sessionId || session_id,
       clientId: clientId || client_id,
@@ -95,11 +96,6 @@ class ConstructorIO {
       eventDispatcher,
       beaconMode: (beaconMode === false) ? false : true, // Defaults to 'true',
     };
-
-    // Enable sending of tracking events by default if no DOM context is available
-    if (!helpers.canUseDOM()) {
-      this.options.sendTrackingEvents = true;
-    }
 
     // Expose global modules
     this.search = new Search(this.options);

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -64,8 +64,8 @@ class ConstructorIO {
     let session_id;
     let client_id;
 
-    // Initialize ID session (if within browser context)
-    if (helpers.hasWindow()) {
+    // Initialize ID session if DOM context is available
+    if (helpers.canUseDOM()) {
       ({ session_id, client_id } = new ConstructorioID(idOptions || {}));
     }
 
@@ -86,11 +86,9 @@ class ConstructorIO {
       beaconMode: (beaconMode === false) ? false : true, // Defaults to 'true',
     };
 
-    // Disable event dispatcher and tracking events if `window` not available
-    if (!helpers.hasWindow()) {
-      if (window !== global) {
-        this.options.sendTrackingEvents = false;
-      }
+    // Disable event dispatcher and tracking events if DOM context is not available
+    if (!helpers.canUseDOM()) {
+      this.options.sendTrackingEvents = false;
 
       if (!this.options.eventDispatcher) {
         this.options.eventDispatcher = {};

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -96,15 +96,9 @@ class ConstructorIO {
       beaconMode: (beaconMode === false) ? false : true, // Defaults to 'true',
     };
 
-    // Disable event dispatcher and tracking events if DOM context is not available
+    // Enable sending of tracking events by default if no DOM context is available
     if (!helpers.canUseDOM()) {
-      this.options.sendTrackingEvents = false;
-
-      if (!this.options.eventDispatcher) {
-        this.options.eventDispatcher = {};
-      }
-
-      this.options.eventDispatcher.enabled = false;
+      this.options.sendTrackingEvents = true;
     }
 
     // Expose global modules

--- a/src/utils/event-dispatcher.js
+++ b/src/utils/event-dispatcher.js
@@ -24,7 +24,7 @@ class EventDispatcher {
       // Check browser environment to determine if beacon has been loaded
       // - Important for the case where the beacon has loaded before client library instantiated
       if (
-        helpers.hasWindow()
+        helpers.canUseDOM()
         && (
           window.ConstructorioAutocomplete
           || window.ConstructorioBeacon

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -46,7 +46,7 @@ const utils = {
     throw error;
   }),
 
-  hasWindow: () => typeof window !== 'undefined',
+  hasWindow: () => typeof window !== 'undefined' && window !== global,
 
   addEventListener: (eventType, callback, useCapture) => {
     if (utils.hasWindow()) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -46,22 +46,24 @@ const utils = {
     throw error;
   }),
 
-  hasWindow: () => typeof window !== 'undefined' && window !== global,
+  canUseDOM: () => !!(
+    (typeof window !== 'undefined' && window.document && window.document.createElement)
+  ),
 
   addEventListener: (eventType, callback, useCapture) => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       window.addEventListener(eventType, callback, useCapture);
     }
   },
 
   removeEventListener: (eventType, callback, useCapture) => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       window.removeEventListener(eventType, callback, useCapture);
     }
   },
 
   getNavigator: () => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       return window.navigator;
     }
 
@@ -74,7 +76,7 @@ const utils = {
   isNil: value => value == null,
 
   getWindowLocation: () => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       return window.location;
     }
 
@@ -82,13 +84,13 @@ const utils = {
   },
 
   dispatchEvent: (event) => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       window.dispatchEvent(event);
     }
   },
 
   createCustomEvent: (eventName, detail) => {
-    if (utils.hasWindow()) {
+    if (utils.canUseDOM()) {
       try {
         return new window.CustomEvent(eventName, { detail });
       } catch (e) {

--- a/src/utils/humanity-check.js
+++ b/src/utils/humanity-check.js
@@ -40,7 +40,7 @@ class HumanityCheck {
 
   // Return boolean indicating if is human
   isHuman() {
-    return this.isHumanBoolean || !!store.session.get(storageKey);
+    return this.isHumanBoolean || !!store.session.get(storageKey) || window === global;
   }
 
   // Return boolean indicating if useragent matches botlist

--- a/src/utils/humanity-check.js
+++ b/src/utils/humanity-check.js
@@ -40,7 +40,7 @@ class HumanityCheck {
 
   // Return boolean indicating if is human
   isHuman() {
-    return this.isHumanBoolean || !!store.session.get(storageKey) || window === global;
+    return this.isHumanBoolean || !!store.session.get(storageKey);
   }
 
   // Return boolean indicating if useragent matches botlist

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -52,7 +52,8 @@ class RequestQueue {
         const queue = RequestQueue.get();
 
         if (
-          this.humanity.isHuman()
+          // Consider user "human" if no DOM context is available
+          (!helpers.canUseDOM() || this.humanity.isHuman())
           && !this.requestPending
           && !this.pageUnloading
           && queue.length


### PR DESCRIPTION
- If DOM context is not available, require client and session identifier to be set on instantiation

- Update DOM context detection method - inspiration from: https://stackoverflow.com/questions/32216383/in-react-how-do-i-detect-if-my-component-is-rendering-from-the-client-or-the-se

- Set sendTrackingEvents to `true` by default if no DOM context is available

- Update tests