### PR TITLE
Update active LTS codename.

### DIFF
--- a/scripts/verify-node-version.sh
+++ b/scripts/verify-node-version.sh
@@ -1,5 +1,5 @@
 version=$(node -pe process.release.lts)
-activeLTSCodename="Fermium"
+activeLTSCodename="Gallium"
 
 if [ $version != $activeLTSCodename ]
 then


### PR DESCRIPTION
Node 16 is now active LTS.

✅ All tests pass