### PR TITLE
[CSL 731] Util Tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,4 @@
 {
-  "presets": ["@babel/preset-env"]
+  "presets": ["@babel/preset-env"],
+  "plugins": ["@babel/plugin-transform-runtime"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
       "devDependencies": {
         "@babel/cli": "^7.15.7",
         "@babel/core": "^7.15.8",
+        "@babel/plugin-transform-runtime": "^7.16.4",
         "@babel/preset-env": "^7.15.8",
         "@babel/register": "^7.15.3",
         "chai": "^4.2.0",
@@ -184,15 +185,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -253,19 +245,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/core/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/core/node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -321,28 +300,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-annotate-as-pure/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-builder-binary-assignment-operator-visitor": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-builder-binary-assignment-operator-visitor/-/helper-builder-binary-assignment-operator-visitor-7.15.4.tgz",
@@ -351,28 +308,6 @@
       "dependencies": {
         "@babel/helper-explode-assignable-expression": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-builder-binary-assignment-operator-visitor/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -475,15 +410,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -519,19 +445,6 @@
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-create-class-features-plugin/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -616,28 +529,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-explode-assignable-expression/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-explode-assignable-expression/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-function-name": {
       "version": "7.12.13",
       "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
@@ -670,28 +561,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-hoist-variables/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-member-expression-to-functions": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.4.tgz",
@@ -704,57 +573,13 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-member-expression-to-functions/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
       "dev": true,
       "dependencies": {
-        "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-module-imports/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
+        "@babel/types": "^7.16.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -843,15 +668,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-transforms/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -912,19 +728,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-module-transforms/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-module-transforms/node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -960,28 +763,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-optimise-call-expression/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
@@ -1000,28 +781,6 @@
         "@babel/helper-annotate-as-pure": "^7.15.4",
         "@babel/helper-wrap-function": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-remap-async-to-generator/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1106,15 +865,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-replace-supers/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -1175,19 +925,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-replace-supers/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-replace-supers/node_modules/debug": {
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -1223,28 +960,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-simple-access/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-simple-access/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-skip-transparent-expression-wrappers": {
       "version": "7.15.4",
       "resolved": "https://registry.npmjs.org/@babel/helper-skip-transparent-expression-wrappers/-/helper-skip-transparent-expression-wrappers-7.15.4.tgz",
@@ -1252,28 +967,6 @@
       "dev": true,
       "dependencies": {
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-skip-transparent-expression-wrappers/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1289,10 +982,13 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
-      "dev": true
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.14.5",
@@ -1382,15 +1078,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helper-wrap-function/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helper-wrap-function/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -1446,19 +1133,6 @@
         "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helper-wrap-function/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1565,15 +1239,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/helpers/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/helpers/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -1629,19 +1294,6 @@
         "@babel/types": "^7.15.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/helpers/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2268,15 +1920,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-classes/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -2312,19 +1955,6 @@
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-classes/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2476,15 +2106,6 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/highlight": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -2520,19 +2141,6 @@
         "@babel/code-frame": "^7.14.5",
         "@babel/parser": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-function-name/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -2620,15 +2228,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
-      }
-    },
-    "node_modules/@babel/plugin-transform-modules-systemjs/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/plugin-transform-modules-umd": {
@@ -2751,6 +2350,116 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime": {
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/@babel/helper-define-polyfill-provider": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+      "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-compilation-targets": "^7.13.0",
+        "@babel/helper-module-imports": "^7.12.13",
+        "@babel/helper-plugin-utils": "^7.13.0",
+        "@babel/traverse": "^7.13.0",
+        "debug": "^4.1.1",
+        "lodash.debounce": "^4.0.8",
+        "resolve": "^1.14.2",
+        "semver": "^6.1.2"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.4.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs2": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+      "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.13.11",
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "semver": "^6.1.1"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-corejs3": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+      "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0",
+        "core-js-compat": "^3.18.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/babel-plugin-polyfill-regenerator": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+      "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": "^0.3.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/debug": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+      "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+      "dev": true,
+      "dependencies": {
+        "ms": "2.1.2"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/ms": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+      "dev": true
+    },
+    "node_modules/@babel/plugin-transform-runtime/node_modules/semver": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/plugin-transform-shorthand-properties": {
@@ -2947,28 +2656,6 @@
         "@babel/core": "^7.0.0-0"
       }
     },
-    "node_modules/@babel/preset-env/node_modules/@babel/helper-validator-identifier": {
-      "version": "7.15.7",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-      "dev": true,
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@babel/preset-env/node_modules/@babel/types": {
-      "version": "7.15.6",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-      "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-      "dev": true,
-      "dependencies": {
-        "@babel/helper-validator-identifier": "^7.14.9",
-        "to-fast-properties": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6.9.0"
-      }
-    },
     "node_modules/@babel/preset-env/node_modules/semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -3076,14 +2763,16 @@
       "dev": true
     },
     "node_modules/@babel/types": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@constructor-io/constructorio-id": {
@@ -10462,12 +10151,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -10513,16 +10196,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -10564,24 +10237,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-builder-binary-assignment-operator-visitor": {
@@ -10592,24 +10247,6 @@
       "requires": {
         "@babel/helper-explode-assignable-expression": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-compilation-targets": {
@@ -10684,12 +10321,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -10716,16 +10347,6 @@
             "@babel/code-frame": "^7.14.5",
             "@babel/parser": "^7.15.4",
             "@babel/types": "^7.15.4"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -10786,24 +10407,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-function-name": {
@@ -10833,24 +10436,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-member-expression-to-functions": {
@@ -10860,51 +10445,15 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-module-imports": {
-      "version": "7.15.4",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.15.4.tgz",
-      "integrity": "sha512-jeAHZbzUwdW/xHgHQ3QmWR4Jg6j15q4w/gCfwZvtqOxoo5DKtLHk8Bsf4c5RZRC7NmLEs+ohkdq8jFefuvIxAA==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.0.tgz",
+      "integrity": "sha512-kkH7sWzKPq0xt3H1n+ghb4xEMP8k0U7XV3kkB+ZGy69kDk2ySFW1qPi06sjKzFY3t1j6XbJSqr4mF9L7CYVyhg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
+        "@babel/types": "^7.16.0"
       }
     },
     "@babel/helper-module-transforms": {
@@ -10972,12 +10521,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -11023,16 +10566,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -11057,24 +10590,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-plugin-utils": {
@@ -11092,24 +10607,6 @@
         "@babel/helper-annotate-as-pure": "^7.15.4",
         "@babel/helper-wrap-function": "^7.15.4",
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-replace-supers": {
@@ -11173,12 +10670,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -11224,16 +10715,6 @@
             "globals": "^11.1.0"
           }
         },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "debug": {
           "version": "4.3.2",
           "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
@@ -11258,24 +10739,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-skip-transparent-expression-wrappers": {
@@ -11285,24 +10748,6 @@
       "dev": true,
       "requires": {
         "@babel/types": "^7.15.4"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        }
       }
     },
     "@babel/helper-split-export-declaration": {
@@ -11315,9 +10760,9 @@
       }
     },
     "@babel/helper-validator-identifier": {
-      "version": "7.12.11",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.12.11.tgz",
-      "integrity": "sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==",
+      "version": "7.15.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
+      "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
       "dev": true
     },
     "@babel/helper-validator-option": {
@@ -11387,12 +10832,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -11436,16 +10875,6 @@
             "@babel/types": "^7.15.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -11525,12 +10954,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -11574,16 +10997,6 @@
             "@babel/types": "^7.15.4",
             "debug": "^4.1.0",
             "globals": "^11.1.0"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
           }
         },
         "debug": {
@@ -12006,12 +11419,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -12038,16 +11445,6 @@
             "@babel/code-frame": "^7.14.5",
             "@babel/parser": "^7.15.4",
             "@babel/types": "^7.15.4"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -12147,12 +11544,6 @@
             "@babel/types": "^7.15.4"
           }
         },
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
         "@babel/highlight": {
           "version": "7.14.5",
           "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
@@ -12179,16 +11570,6 @@
             "@babel/code-frame": "^7.14.5",
             "@babel/parser": "^7.15.4",
             "@babel/types": "^7.15.4"
-          }
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
           }
         }
       }
@@ -12245,14 +11626,6 @@
         "@babel/helper-plugin-utils": "^7.14.5",
         "@babel/helper-validator-identifier": "^7.14.9",
         "babel-plugin-dynamic-import-node": "^2.3.3"
-      },
-      "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        }
       }
     },
     "@babel/plugin-transform-modules-umd": {
@@ -12327,6 +11700,89 @@
       "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-runtime": {
+      "version": "7.16.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.16.4.tgz",
+      "integrity": "sha512-pru6+yHANMTukMtEZGC4fs7XPwg35v8sj5CIEmE+gEkFljFiVJxEWxx/7ZDkTK+iZRYo1bFXBtfIN95+K3cJ5A==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-module-imports": "^7.16.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "babel-plugin-polyfill-corejs2": "^0.3.0",
+        "babel-plugin-polyfill-corejs3": "^0.4.0",
+        "babel-plugin-polyfill-regenerator": "^0.3.0",
+        "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "@babel/helper-define-polyfill-provider": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.3.0.tgz",
+          "integrity": "sha512-7hfT8lUljl/tM3h+izTX/pO3W3frz2ok6Pk+gzys8iJqDfZrZy2pXjRTZAvG2YmfHun1X4q8/UZRLatMfqc5Tg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-compilation-targets": "^7.13.0",
+            "@babel/helper-module-imports": "^7.12.13",
+            "@babel/helper-plugin-utils": "^7.13.0",
+            "@babel/traverse": "^7.13.0",
+            "debug": "^4.1.1",
+            "lodash.debounce": "^4.0.8",
+            "resolve": "^1.14.2",
+            "semver": "^6.1.2"
+          }
+        },
+        "babel-plugin-polyfill-corejs2": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.3.0.tgz",
+          "integrity": "sha512-wMDoBJ6uG4u4PNFh72Ty6t3EgfA91puCuAwKIazbQlci+ENb/UU9A3xG5lutjUIiXCIn1CY5L15r9LimiJyrSA==",
+          "dev": true,
+          "requires": {
+            "@babel/compat-data": "^7.13.11",
+            "@babel/helper-define-polyfill-provider": "^0.3.0",
+            "semver": "^6.1.1"
+          }
+        },
+        "babel-plugin-polyfill-corejs3": {
+          "version": "0.4.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.4.0.tgz",
+          "integrity": "sha512-YxFreYwUfglYKdLUGvIF2nJEsGwj+RhWSX/ije3D2vQPOXuyMLMtg/cCGMDpOA7Nd+MwlNdnGODbd2EwUZPlsw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.3.0",
+            "core-js-compat": "^3.18.0"
+          }
+        },
+        "babel-plugin-polyfill-regenerator": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.3.0.tgz",
+          "integrity": "sha512-dhAPTDLGoMW5/84wkgwiLRwMnio2i1fUe53EuvtKMv0pn2p3S8OCoV1xAzfJPl0KOX7IB89s2ib85vbYiea3jg==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-define-polyfill-provider": "^0.3.0"
+          }
+        },
+        "debug": {
+          "version": "4.3.2",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
+          "integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
+        }
       }
     },
     "@babel/plugin-transform-shorthand-properties": {
@@ -12475,22 +11931,6 @@
         "semver": "^6.3.0"
       },
       "dependencies": {
-        "@babel/helper-validator-identifier": {
-          "version": "7.15.7",
-          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz",
-          "integrity": "sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==",
-          "dev": true
-        },
-        "@babel/types": {
-          "version": "7.15.6",
-          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.6.tgz",
-          "integrity": "sha512-BPU+7QhqNjmWyDO0/vitH/CuhpV8ZmK1wpKva8nuyNF5MJfuRNWMc+hc14+u9xT93kvykMdncrJT19h74uB1Ig==",
-          "dev": true,
-          "requires": {
-            "@babel/helper-validator-identifier": "^7.14.9",
-            "to-fast-properties": "^2.0.0"
-          }
-        },
         "semver": {
           "version": "6.3.0",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
@@ -12579,13 +12019,12 @@
       }
     },
     "@babel/types": {
-      "version": "7.13.14",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.13.14.tgz",
-      "integrity": "sha512-A2aa3QTkWoyqsZZFl56MLUsfmh7O0gN41IPvXAE/++8ojpbz12SszD7JEGYVdn4f9Kt4amIei07swF1h4AqmmQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.0.tgz",
+      "integrity": "sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.12.11",
-        "lodash": "^4.17.19",
+        "@babel/helper-validator-identifier": "^7.15.7",
         "to-fast-properties": "^2.0.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
   "devDependencies": {
     "@babel/cli": "^7.15.7",
     "@babel/core": "^7.15.8",
+    "@babel/plugin-transform-runtime": "^7.16.4",
     "@babel/preset-env": "^7.15.8",
     "@babel/register": "^7.15.3",
     "chai": "^4.2.0",

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -19,7 +19,7 @@ dotenv.config();
 
 const bundled = process.env.BUNDLED === 'true';
 
-describe.only('ConstructorIO - Utils - Helpers', () => {
+describe('ConstructorIO - Utils - Helpers', () => {
   if (!bundled) {
     describe('ourEncodeURIComponent', () => {
       it('should encode `+` as spaces (%20)', () => {
@@ -70,42 +70,33 @@ describe.only('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe.only('throwHttpErrorFromResponse', () => {
-      it('should throw an error based on the information from the response', () => {
+      it('should throw an error based on the information from the response', async () => {
+        const errorMessage = 'Error Message';
+        const responseData = {
+          status: 400,
+          statusText: 'Bad Request',
+          url: 'https://constructor.io',
+          headers: {
+            'x-forwarded-for': '192.168.0.1',
+          },
+        };
+
         try {
-          throwHttpErrorFromResponse(new Error(), {
-            json: () => new Promise((resolve2) => {
-              resolve2({
-                message: 'Error Message',
+          await throwHttpErrorFromResponse(new Error(), {
+            json: () => new Promise((resolve) => {
+              resolve({
+                message: errorMessage,
               });
             }),
-            status: 400,
-            statusText: 'Bad Request',
-            url: 'https://constructor.io',
-            headers: {
-              'x-forwarded-for': '192.168.0.1',
-            },
+            ...responseData,
           });
         } catch (e) {
-          console.log(e);
-          expect(e).to.equal();
+          expect(e.message).to.equal(errorMessage);
+          expect(e.status).to.equal(responseData.status);
+          expect(e.statusText).to.equal(responseData.statusText);
+          expect(e.url).to.equal(responseData.url);
+          expect(e.headers).to.deep.equal(responseData.headers);
         }
-        // expect(
-        //   new Promise((resolve, reject) => {
-        //     reject(throwHttpErrorFromResponse(new Error(), {
-        //       json: () => new Promise((resolve2) => {
-        //         resolve2({
-        //           message: 'Error Message',
-        //         });
-        //       }),
-        //       status: 400,
-        //       statusText: 'Bad Request',
-        //       url: 'https://constructor.io',
-        //       headers: {
-        //         'x-forwarded-for': '192.168.0.1',
-        //       },
-        //     }));
-        //   })
-        // ).to.eventually.be.rejectedWith(Error('Error Message'));
       });
     });
 

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -20,7 +20,7 @@ const {
   hasOrderIdRecord,
   addOrderIdRecord,
   applyNetworkTimeout,
-} = require('../../../src/utils/helpers');
+} = require('../../../test/utils/helpers'); // eslint-disable-line import/extensions
 const { setupDOM, teardownDOM } = require('../../mocha.helpers');
 const store = require('../../../test/utils/store'); // eslint-disable-line import/extensions
 

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -1,0 +1,40 @@
+/* eslint-disable import/no-unresolved */
+const dotenv = require('dotenv');
+const chai = require('chai');
+const chaiAsPromised = require('chai-as-promised');
+const store = require('../../../test/utils/store'); // eslint-disable-line import/extensions
+const HumanityCheck = require('../../../test/utils/humanity-check'); // eslint-disable-line import/extensions
+const helpers = require('../../mocha.helpers');
+const { expect } = require('chai');
+
+chai.use(chaiAsPromised);
+dotenv.config();
+
+const bundled = process.env.BUNDLED === 'true';
+
+describe('ConstructorIO - Utils - Helpers', () => {
+  if (!bundled) {
+    describe('ourEncodeURIComponent', () => {
+      it('should encode `+` as spaces (%20)', () => {
+        const string = 'boink+doink';
+        const encodedString = encodeURIComponent(string);
+
+        expect(encodedString).to.equal('boink%20doink');
+      });
+
+      it('should encode special characters', () => {
+        const string = 'q=jáck%27s+boinks%2Fyoinks+%26+doinks'; // 'jáck's boink/yoink & doinks'
+        const encodedString = encodeURIComponent(string);
+
+        expect(encodedString).to.equal('boink%20doink');
+      });
+
+      it('should encode non-breaking space characters as spaces (%20)', () => {
+        const string = 'q=boink%C2%A0doink%C2%A0yoink'; // contains non-breaking spaces
+        const encodedString = encodeURIComponent(string);
+
+        expect(encodedString).to.equal('boink%20doink');
+      });
+    });
+  }
+});

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -35,35 +35,35 @@ const bundled = process.env.BUNDLED === 'true';
 describe('ConstructorIO - Utils - Helpers', () => {
   if (!bundled) {
     describe('ourEncodeURIComponent', () => {
-      it('should encode `+` as spaces (%20)', () => {
+      it('Should encode `+` as spaces (%20)', () => {
         const string = 'boink+doink';
         const encodedString = ourEncodeURIComponent(string);
 
         expect(encodedString).to.equal('boink%20doink');
       });
 
-      it('should encode special characters', () => {
+      it('Should encode special characters', () => {
         const string = "jáck's boink/yoink & doinks";
         const encodedString = ourEncodeURIComponent(string);
 
         expect(encodedString).to.equal('j%C3%A1ck%27s%20boink%2Fyoink%20%26%20doinks');
       });
 
-      it('should encode non-breaking space characters as spaces (%20)', () => {
+      it('Should encode non-breaking space characters as spaces (%20)', () => {
         const string = 'boink doink yoink'; // contains non-breaking spaces
         const encodedString = ourEncodeURIComponent(string);
 
         expect(encodedString).to.equal('boink%20doink%20yoink');
       });
 
-      it('should return null if it is not a string', () => {
+      it('Should return null if it is not a string', () => {
         const notAString = 123;
         expect(ourEncodeURIComponent(notAString)).to.equal(null);
       });
     });
 
     describe('cleanParams', () => {
-      it('should clean up parameters', () => {
+      it('Should clean up parameters', () => {
         const params = {
           origin_referrer: 'https://test.com/search/pizza?a=bread&b=pizza+burrito',
           filters: {
@@ -88,7 +88,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('throwHttpErrorFromResponse', () => {
-      it('should throw an error based on the information from the response', async () => {
+      it('Should throw an error based on the information from the response', async () => {
         const errorMessage = 'Error Message';
         const responseData = {
           status: 400,
@@ -119,11 +119,11 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('canUseDOM', () => {
-      it('should return true if in a DOM context', () => {
+      it('Should return true if in a DOM context', () => {
         expect(canUseDOM()).to.equal(false);
       });
 
-      it('should return false if not in a DOM context', () => {
+      it('Should return false if not in a DOM context', () => {
         setupDOM();
         expect(canUseDOM()).to.equal(true);
         teardownDOM();
@@ -131,7 +131,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('addEventListener', () => {
-      it('should add an event listener to the window if in the DOM context', () => {
+      it('Should add an event listener to the window if in the DOM context', () => {
         setupDOM();
 
         const callback = sinon.stub();
@@ -145,7 +145,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         teardownDOM();
       });
 
-      it('should not add an event listener to the window if not in a DOM context', () => {
+      it('Should not add an event listener to the window if not in a DOM context', () => {
         const callback = sinon.stub();
         addEventListener('click', callback, false);
 
@@ -160,7 +160,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('removeEventListener', () => {
-      it('should remove an event listener to the window if in a DOM context', () => {
+      it('Should remove an event listener to the window if in a DOM context', () => {
         setupDOM();
 
         const callback = sinon.stub();
@@ -182,7 +182,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('getNavigator', () => {
-      it('should return information about the window navigator property if in a DOM context', () => {
+      it('Should return information about the window navigator property if in a DOM context', () => {
         setupDOM();
 
         const navigatorInfo = {
@@ -198,7 +198,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         teardownDOM();
       });
 
-      it('should return default information if not in a DOM context', () => {
+      it('Should return default information if not in a DOM context', () => {
         expect(getNavigator()).to.deep.equal({
           userAgent: '',
           webdriver: false,
@@ -207,17 +207,17 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('isNil', () => {
-      it('should return true if the value is null', () => {
+      it('Should return true if the value is null', () => {
         expect(isNil(null)).to.equal(true);
       });
 
-      it('should return false if the value is not null', () => {
+      it('Should return false if the value is not null', () => {
         expect(isNil({})).to.equal(false);
       });
     });
 
     describe('getWindowLocation', () => {
-      it('should return information about the window location property if in a DOM context', () => {
+      it('Should return information about the window location property if in a DOM context', () => {
         setupDOM();
 
         const locationInfo = {
@@ -234,13 +234,13 @@ describe('ConstructorIO - Utils - Helpers', () => {
         teardownDOM();
       });
 
-      it('should return empty object if not in a DOM context', () => {
+      it('Should return empty object if not in a DOM context', () => {
         expect(getWindowLocation()).to.deep.equal({});
       });
     });
 
     describe('dispatchEvent', () => {
-      it('should dispatch an event if in a DOM context', () => {
+      it('Should dispatch an event if in a DOM context', () => {
         setupDOM();
 
         const windowDispatch = sinon.spy(window, 'dispatchEvent');
@@ -252,7 +252,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('createCustomEvent', () => {
-      it('should create a custom event if in a DOM context', () => {
+      it('Should create a custom event if in a DOM context', () => {
         setupDOM();
 
         const eventName = 'custom.event';
@@ -265,7 +265,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         teardownDOM();
       });
 
-      it('should not create a custom event if not in a DOM context', () => {
+      it('Should not create a custom event if not in a DOM context', () => {
         expect(createCustomEvent('cio.loaded', { a: 1, b: 2 })).to.equal(null);
       });
     });
@@ -277,7 +277,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         store.session.clearAll();
       });
 
-      it('should return true if the order id already exists from a previous purchase event', () => {
+      it('Should return true if the order id already exists from a previous purchase event', () => {
         store.session.set(purchaseEventStorageKey, JSON.stringify({
           [CRC32.str(orderId)]: true,
         }));
@@ -285,7 +285,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(hasOrderIdRecord(orderId)).to.equal(true);
       });
 
-      it('should return null if the order id does not already exist', () => {
+      it('Should return null if the order id does not already exist', () => {
         expect(hasOrderIdRecord(orderId)).to.equal(null);
       });
     });
@@ -299,7 +299,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         store.session.clearAll();
       });
 
-      it('should add the order id to the purchase event storage', () => {
+      it('Should add the order id to the purchase event storage', () => {
         const orderIds = store.session.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
@@ -310,7 +310,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(newOrderIdExists).to.equal(true);
       });
 
-      it('should not add duplicate order ids to the purchase event storage', () => {
+      it('Should not add duplicate order ids to the purchase event storage', () => {
         const orderIds = store.session.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
@@ -323,7 +323,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(newOrderIdExists).to.equal(true);
       });
 
-      it('should keep a history of order ids', () => {
+      it('Should keep a history of order ids', () => {
         const orderIds = store.session.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
@@ -340,7 +340,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('applyNetworkTimeout', () => {
-      it('should send an abort signal to the controller using the networkParameter timeout', (done) => {
+      it('Should send an abort signal to the controller using the networkParameter timeout', (done) => {
         const controller = new AbortController();
 
         expect(controller.signal.aborted).to.equal(false);
@@ -352,7 +352,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         }, 100);
       });
 
-      it('should send an abort signal to the controller using the options timeout', (done) => {
+      it('Should send an abort signal to the controller using the options timeout', (done) => {
         const controller = new AbortController();
 
         expect(controller.signal.aborted).to.equal(false);
@@ -362,6 +362,18 @@ describe('ConstructorIO - Utils - Helpers', () => {
           expect(controller.signal.aborted).to.equal(true);
           done();
         }, 100);
+      });
+
+      it('Should prefer timeout value from options (first parameter) over global timeout from networkParameters (second parameter)', (done) => {
+        const controller = new AbortController();
+
+        expect(controller.signal.aborted).to.equal(false);
+        applyNetworkTimeout({ networkParameters: { timeout: 50 } }, { timeout: 100 }, controller);
+
+        setTimeout(() => {
+          expect(controller.signal.aborted).to.equal(true);
+          done();
+        }, 75);
       });
     });
   }

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -1,17 +1,30 @@
-/* eslint-disable import/no-unresolved */
+/* eslint-disable import/no-unresolved, no-unused-expressions */
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
+const CRC32 = require('crc-32');
 const sinonChai = require('sinon-chai');
 const {
   ourEncodeURIComponent,
   cleanParams,
   throwHttpErrorFromResponse,
   canUseDOM,
+  addEventListener,
+  removeEventListener,
+  getNavigator,
+  isNil,
+  getWindowLocation,
+  dispatchEvent,
+  createCustomEvent,
+  hasOrderIdRecord,
+  addOrderIdRecord,
+  applyNetworkTimeout,
 } = require('../../../src/utils/helpers');
-const { expect } = require('chai');
 const { setupDOM, teardownDOM } = require('../../mocha.helpers');
+const store = require('../../../test/utils/store'); // eslint-disable-line import/extensions
+
+const purchaseEventStorageKey = '_constructorio_purchase_order_ids';
 
 chai.use(chaiAsPromised);
 chai.use(sinonChai);
@@ -69,7 +82,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
       });
     });
 
-    describe.only('throwHttpErrorFromResponse', () => {
+    describe('throwHttpErrorFromResponse', () => {
       it('should throw an error based on the information from the response', async () => {
         const errorMessage = 'Error Message';
         const responseData = {
@@ -100,24 +113,221 @@ describe('ConstructorIO - Utils - Helpers', () => {
       });
     });
 
-    // describe('canUseDOM', () => {
-    //   it('should return true if we are in a context containing a DOM', () => {
-    //     expect(canUseDOM()).to.equal(false);
-    //   });
+    describe('canUseDOM', () => {
+      it('should return true if in a DOM context', () => {
+        expect(canUseDOM()).to.equal(false);
+      });
 
-    //   it('should return false if we are not in a context containing a DOM', () => {
-    //     setupDOM();
-    //     expect(canUseDOM()).to.equal(true);
-    //     teardownDOM();
-    //   });
-    // });
+      it('should return false if not in a DOM context', () => {
+        setupDOM();
+        expect(canUseDOM()).to.equal(true);
+        teardownDOM();
+      });
+    });
 
-    // describe('addEventListener', () => {
+    describe('addEventListener', () => {
+      it('should add an event listener to the window if in the DOM context', () => {
+        setupDOM();
 
-    // });
+        const callback = sinon.stub();
+        const clickEvent = new window.Event('click', { bubbles: true });
 
-    // describe('removeEventListener', () => {
+        addEventListener('click', callback, false);
+        document.dispatchEvent(clickEvent);
 
-    // });
+        expect(callback).to.have.been.called;
+
+        teardownDOM();
+      });
+
+      it('should not add an event listener to the window if not in a DOM context', () => {
+        const callback = sinon.stub();
+        addEventListener('click', callback, false);
+
+        try {
+          const clickEvent = new window.Event('click', { bubbles: true });
+          document.dispatchEvent(clickEvent);
+        } catch (e) {
+          expect(e.message).to.equal('window is not defined');
+          expect(callback).to.not.have.been.called;
+        }
+      });
+    });
+
+    describe('removeEventListener', () => {
+      it('should remove an event listener to the window if in a DOM context', () => {
+        setupDOM();
+
+        const callback = sinon.stub();
+        const clickEvent = new window.Event('click', { bubbles: true });
+
+        addEventListener('click', callback, false);
+        document.dispatchEvent(clickEvent);
+
+        expect(callback).to.have.been.calledOnce;
+
+        removeEventListener('click', callback, false);
+        document.dispatchEvent(clickEvent);
+
+        // Make sure that the handler was still called only once
+        expect(callback).to.have.been.calledOnce;
+
+        teardownDOM();
+      });
+    });
+
+    describe('getNavigator', () => {
+      it('should return information about the window navigator property if in a DOM context', () => {
+        setupDOM();
+
+        const navigatorInfo = {
+          userAgent: '',
+          webdriver: true,
+        };
+        Object.defineProperty(window, 'navigator', {
+          get: () => navigatorInfo,
+        });
+
+        expect(getNavigator()).to.deep.equal(navigatorInfo);
+
+        teardownDOM();
+      });
+
+      it('should return default information if not in a DOM context', () => {
+        expect(getNavigator()).to.deep.equal({
+          userAgent: '',
+          webdriver: false,
+        });
+      });
+    });
+
+    describe('isNil', () => {
+      it('should return true if the value is null', () => {
+        expect(isNil(null)).to.equal(true);
+      });
+
+      it('should return false if the value is not null', () => {
+        expect(isNil({})).to.equal(false);
+      });
+    });
+
+    describe('getWindowLocation', () => {
+      it('should return information about the window location property if in a DOM context', () => {
+        setupDOM();
+
+        const locationInfo = {
+          hostname: 'constructor.io',
+          protocol: 'https',
+          path: '/home',
+        };
+        Object.defineProperty(window, 'location', {
+          get: () => locationInfo,
+        });
+
+        expect(getWindowLocation()).to.deep.equal(locationInfo);
+
+        teardownDOM();
+      });
+
+      it('should return empty object if not in a DOM context', () => {
+        expect(getWindowLocation()).to.deep.equal({});
+      });
+    });
+
+    describe('dispatchEvent', () => {
+      it('should dispatch an event if in a DOM context', () => {
+        setupDOM();
+
+        const windowDispatch = sinon.spy(window, 'dispatchEvent');
+        dispatchEvent(new window.Event('click'));
+        expect(windowDispatch).to.have.been.called;
+
+        teardownDOM();
+      });
+    });
+
+    describe('createCustomEvent', () => {
+      it('should create a custom event if in a DOM context', () => {
+        setupDOM();
+
+        const eventName = 'custom.event';
+        const eventDetails = { a: 1, b: 2 };
+        const customEvent = createCustomEvent(eventName, eventDetails);
+
+        expect(customEvent.type).to.equal(eventName);
+        expect(customEvent.detail).to.deep.equal(eventDetails);
+
+        teardownDOM();
+      });
+
+      it('should not create a custom event if not in a DOM context', () => {
+        expect(createCustomEvent('cio.loaded', { a: 1, b: 2 })).to.equal(null);
+      });
+    });
+
+    describe('hasOrderIdRecord', () => {
+      const orderId = '12345';
+
+      afterEach(() => {
+        store.session.clearAll();
+      });
+
+      it('should return true if the order id already exists from a previous purchase event', () => {
+        store.session.set(purchaseEventStorageKey, JSON.stringify({
+          [CRC32.str(orderId)]: true,
+        }));
+
+        expect(hasOrderIdRecord(orderId)).to.equal(true);
+      });
+
+      it('should return null if the order id does not already exist', () => {
+        expect(hasOrderIdRecord(orderId)).to.equal(null);
+      });
+    });
+
+    describe('addOrderIdRecord', () => {
+      const orderId = '67890';
+
+      afterEach(() => {
+        store.session.clearAll();
+      });
+
+      it('should add the order id to the purchase event storage', () => {
+        const orderIds = store.session.get(purchaseEventStorageKey);
+        expect(orderIds).to.equal(null);
+
+        addOrderIdRecord(orderId);
+        const newOrderIds = JSON.parse(store.session.get(purchaseEventStorageKey));
+        const newOrderIdExists = newOrderIds[CRC32.str(orderId)];
+
+        expect(newOrderIdExists).to.equal(true);
+      });
+    });
+
+    describe('applyNetworkTimeout', () => {
+      it('should send an abort signal to the controller using the networkParameter timeout', (done) => {
+        const controller = new AbortController();
+
+        expect(controller.signal.aborted).to.equal(false);
+        applyNetworkTimeout(null, { timeout: 50 }, controller);
+
+        setTimeout(() => {
+          expect(controller.signal.aborted).to.equal(true);
+          done();
+        }, 100);
+      });
+
+      it('should send an abort signal to the controller using the options timeout', (done) => {
+        const controller = new AbortController();
+
+        expect(controller.signal.aborted).to.equal(false);
+        applyNetworkTimeout({ networkParameters: { timeout: 50 } }, null, controller);
+
+        setTimeout(() => {
+          expect(controller.signal.aborted).to.equal(true);
+          done();
+        }, 100);
+      });
+    });
   }
 });

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -32,7 +32,7 @@ dotenv.config();
 
 const bundled = process.env.BUNDLED === 'true';
 
-describe.only('ConstructorIO - Utils - Helpers', () => {
+describe('ConstructorIO - Utils - Helpers', () => {
   if (!bundled) {
     describe('ourEncodeURIComponent', () => {
       it('should encode `+` as spaces (%20)', () => {

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -2,39 +2,131 @@
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
-const store = require('../../../test/utils/store'); // eslint-disable-line import/extensions
-const HumanityCheck = require('../../../test/utils/humanity-check'); // eslint-disable-line import/extensions
-const helpers = require('../../mocha.helpers');
+const sinon = require('sinon');
+const sinonChai = require('sinon-chai');
+const {
+  ourEncodeURIComponent,
+  cleanParams,
+  throwHttpErrorFromResponse,
+  canUseDOM,
+} = require('../../../src/utils/helpers');
 const { expect } = require('chai');
+const { setupDOM, teardownDOM } = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);
+chai.use(sinonChai);
 dotenv.config();
 
 const bundled = process.env.BUNDLED === 'true';
 
-describe('ConstructorIO - Utils - Helpers', () => {
+describe.only('ConstructorIO - Utils - Helpers', () => {
   if (!bundled) {
     describe('ourEncodeURIComponent', () => {
       it('should encode `+` as spaces (%20)', () => {
         const string = 'boink+doink';
-        const encodedString = encodeURIComponent(string);
+        const encodedString = ourEncodeURIComponent(string);
 
         expect(encodedString).to.equal('boink%20doink');
       });
 
       it('should encode special characters', () => {
-        const string = 'q=jáck%27s+boinks%2Fyoinks+%26+doinks'; // 'jáck's boink/yoink & doinks'
-        const encodedString = encodeURIComponent(string);
+        const string = "jáck's boink/yoink & doinks";
+        const encodedString = ourEncodeURIComponent(string);
 
-        expect(encodedString).to.equal('boink%20doink');
+        expect(encodedString).to.equal('j%C3%A1ck%27s%20boink%2Fyoink%20%26%20doinks');
       });
 
       it('should encode non-breaking space characters as spaces (%20)', () => {
-        const string = 'q=boink%C2%A0doink%C2%A0yoink'; // contains non-breaking spaces
-        const encodedString = encodeURIComponent(string);
+        const string = 'boink doink yoink'; // contains non-breaking spaces
+        const encodedString = ourEncodeURIComponent(string);
 
-        expect(encodedString).to.equal('boink%20doink');
+        expect(encodedString).to.equal('boink%20doink%20yoink');
       });
     });
+
+    describe('cleanParams', () => {
+      it('should clean up parameters', () => {
+        const params = {
+          origin_referrer: 'https://test.com/search/pizza?a=bread&b=pizza+burrito',
+          filters: {
+            size: 'large',
+            color: 'green',
+          },
+          userId: 'boink doink yoink', // contains non-breaking spaces
+          section: 'Products',
+        };
+        const cleanedParams = cleanParams(params);
+
+        expect(cleanedParams).to.deep.equal({
+          origin_referrer: 'https://test.com/search/pizza?a=bread&b=pizza burrito',
+          filters: {
+            size: 'large',
+            color: 'green',
+          },
+          userId: 'boink doink yoink', // contains non-breaking spaces
+          section: 'Products',
+        });
+      });
+    });
+
+    describe.only('throwHttpErrorFromResponse', () => {
+      it('should throw an error based on the information from the response', () => {
+        try {
+          throwHttpErrorFromResponse(new Error(), {
+            json: () => new Promise((resolve2) => {
+              resolve2({
+                message: 'Error Message',
+              });
+            }),
+            status: 400,
+            statusText: 'Bad Request',
+            url: 'https://constructor.io',
+            headers: {
+              'x-forwarded-for': '192.168.0.1',
+            },
+          });
+        } catch (e) {
+          console.log(e);
+          expect(e).to.equal();
+        }
+        // expect(
+        //   new Promise((resolve, reject) => {
+        //     reject(throwHttpErrorFromResponse(new Error(), {
+        //       json: () => new Promise((resolve2) => {
+        //         resolve2({
+        //           message: 'Error Message',
+        //         });
+        //       }),
+        //       status: 400,
+        //       statusText: 'Bad Request',
+        //       url: 'https://constructor.io',
+        //       headers: {
+        //         'x-forwarded-for': '192.168.0.1',
+        //       },
+        //     }));
+        //   })
+        // ).to.eventually.be.rejectedWith(Error('Error Message'));
+      });
+    });
+
+    // describe('canUseDOM', () => {
+    //   it('should return true if we are in a context containing a DOM', () => {
+    //     expect(canUseDOM()).to.equal(false);
+    //   });
+
+    //   it('should return false if we are not in a context containing a DOM', () => {
+    //     setupDOM();
+    //     expect(canUseDOM()).to.equal(true);
+    //     teardownDOM();
+    //   });
+    // });
+
+    // describe('addEventListener', () => {
+
+    // });
+
+    // describe('removeEventListener', () => {
+
+    // });
   }
 });

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -5,7 +5,7 @@ const chaiAsPromised = require('chai-as-promised');
 const sinon = require('sinon');
 const sinonChai = require('sinon-chai');
 const store = require('../../../src/utils/store');
-const RequestQueue = require('../../../src/utils/request-queue');
+const RequestQueue = require('../../../test/utils/request-queue'); // eslint-disable-line import/extensions
 const helpers = require('../../mocha.helpers');
 
 chai.use(chaiAsPromised);


### PR DESCRIPTION
### Updates:
* Add tests around util helpers
* Bring in `@babel/plugin-transform-runtime` to be able to use `async`/`await` in tests
* All tests pass
* Not 100% coverage, but I don't think it's possible to test the catch block (screenshot below) of `createCustomEvent` without actually passing a variable that hasn't been defined yet which would fail the catch statement too.
    * Looks like CustomEvent can take a bunch of different things, even empty objects, null, etc.
* Update `request-queue` spec to point to `test` directory

<img width="1024" alt="Screen Shot 2021-11-22 at 4 19 19 PM" src="https://user-images.githubusercontent.com/7194266/142954132-dd5e8e08-eab2-4d01-b0a3-2a11d7b4220b.png">
<img width="520" alt="Screen Shot 2021-11-22 at 4 21 00 PM" src="https://user-images.githubusercontent.com/7194266/142954164-2748fb5f-b7ac-47be-8079-b773f8894c41.png">