### PR TITLE
[CSL-1610] Store order_ids in local storage instead.

### DIFF
--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -282,11 +282,13 @@ describe(`ConstructorIO - Autocomplete${bundledDescriptionSuffix}`, () => {
 
       autocomplete.getAutocompleteResults(query, { hiddenFields }, {}).then((res) => {
         const requestedUrlParams = helpers.extractUrlParamsFromFetch(fetchSpy);
+        const item = res.sections.Products.find((product) => product.data.testField);
+        const itemData = item && item.data;
 
         expect(res).to.have.property('request').to.be.an('object');
         expect(res).to.have.property('sections').to.be.an('object');
         expect(res).to.have.property('result_id').to.be.an('string');
-        expect(res.sections.Products[0].data).to.have.property('testField').to.eql('hiddenFieldValue');
+        expect(itemData).to.have.property('testField').to.eql('hiddenFieldValue');
         expect(res.request.fmt_options.hidden_fields).to.eql(hiddenFields);
         expect(requestedUrlParams.fmt_options).to.have.property('hidden_fields').to.eql(hiddenFields);
         done();

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -1297,7 +1297,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
   });
 
   describe('getBrowseFacetOptions', () => {
-    const facetName = 'color';
+    const facetName = 'Color';
 
     it('Should return a response with a facet name without any parameters', (done) => {
       const { browse } = new ConstructorIO({

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4585,7 +4585,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
     const requiredParameters = {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
       filter_name: 'group_id',
-      filter_value: 'Clothing',
+      filter_value: 'BrandXY',
     };
     const optionalParameters = {
       section: 'Products',
@@ -4799,7 +4799,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
     });
 
-    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+    it.only('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4799,7 +4799,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackBrowseResultClick(parameters)).to.equal(true);
     });
 
-    it.only('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
+    it('Should respond with a valid response when required parameters and non-existent item id are provided', (done) => {
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -279,7 +279,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(newOrderIdExists).to.equal(true);
       });
 
-      it.only('Should limit order ids to 10', () => {
+      it('Should limit order ids to 10', () => {
         let orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -279,6 +279,20 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(newOrderIdExists).to.equal(true);
       });
 
+      it.only('Should limit order ids to 10', () => {
+        let orderIds = store.local.get(purchaseEventStorageKey);
+        expect(orderIds).to.equal(null);
+
+        store.local.set(purchaseEventStorageKey, JSON.stringify([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]));
+        orderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
+        expect(orderIds).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
+
+        addOrderIdRecord(orderId);
+        const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
+
+        expect(newOrderIds).to.eql([3, 4, 5, 6, 7, 8, 9, 10, 11, CRC32.str(orderId)]);
+      });
+
       it('Should not add duplicate order ids to the purchase event storage', () => {
         const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -245,11 +245,11 @@ describe('ConstructorIO - Utils - Helpers', () => {
       const orderId = '12345';
 
       afterEach(() => {
-        store.session.clearAll();
+        store.local.clearAll();
       });
 
       it('Should return true if the order id already exists from a previous purchase event', () => {
-        store.session.set(purchaseEventStorageKey, JSON.stringify({
+        store.local.set(purchaseEventStorageKey, JSON.stringify({
           [CRC32.str(orderId)]: true,
         }));
 
@@ -267,27 +267,27 @@ describe('ConstructorIO - Utils - Helpers', () => {
       const orderId3 = '45124';
 
       afterEach(() => {
-        store.session.clearAll();
+        store.local.clearAll();
       });
 
       it('Should add the order id to the purchase event storage', () => {
-        const orderIds = store.session.get(purchaseEventStorageKey);
+        const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
         addOrderIdRecord(orderId);
-        const newOrderIds = JSON.parse(store.session.get(purchaseEventStorageKey));
+        const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
         const newOrderIdExists = newOrderIds[CRC32.str(orderId)];
 
         expect(newOrderIdExists).to.equal(true);
       });
 
       it('Should not add duplicate order ids to the purchase event storage', () => {
-        const orderIds = store.session.get(purchaseEventStorageKey);
+        const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
         addOrderIdRecord(orderId);
         addOrderIdRecord(orderId);
-        const newOrderIds = JSON.parse(store.session.get(purchaseEventStorageKey));
+        const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
         const newOrderIdExists = newOrderIds[CRC32.str(orderId)];
 
         expect(Object.keys(newOrderIds).length).to.equal(1);
@@ -295,13 +295,13 @@ describe('ConstructorIO - Utils - Helpers', () => {
       });
 
       it('Should keep a history of order ids', () => {
-        const orderIds = store.session.get(purchaseEventStorageKey);
+        const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
         addOrderIdRecord(orderId);
         addOrderIdRecord(orderId2);
         addOrderIdRecord(orderId3);
-        const newOrderIds = JSON.parse(store.session.get(purchaseEventStorageKey));
+        const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
 
         expect(Object.keys(newOrderIds).length).to.equal(3);
         expect(newOrderIds[CRC32.str(orderId)]).to.equal(true);

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -249,9 +249,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
       });
 
       it('Should return true if the order id already exists from a previous purchase event', () => {
-        store.local.set(purchaseEventStorageKey, JSON.stringify({
-          [CRC32.str(orderId)]: true,
-        }));
+        store.local.set(purchaseEventStorageKey, JSON.stringify([CRC32.str(orderId)]));
 
         expect(hasOrderIdRecord(orderId)).to.equal(true);
       });
@@ -276,7 +274,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
 
         addOrderIdRecord(orderId);
         const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
-        const newOrderIdExists = newOrderIds[CRC32.str(orderId)];
+        const newOrderIdExists = newOrderIds.includes(CRC32.str(orderId));
 
         expect(newOrderIdExists).to.equal(true);
       });
@@ -288,9 +286,9 @@ describe('ConstructorIO - Utils - Helpers', () => {
         addOrderIdRecord(orderId);
         addOrderIdRecord(orderId);
         const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
-        const newOrderIdExists = newOrderIds[CRC32.str(orderId)];
+        const newOrderIdExists = newOrderIds.includes(CRC32.str(orderId));
 
-        expect(Object.keys(newOrderIds).length).to.equal(1);
+        expect(newOrderIds.length).to.equal(1);
         expect(newOrderIdExists).to.equal(true);
       });
 
@@ -304,9 +302,9 @@ describe('ConstructorIO - Utils - Helpers', () => {
         const newOrderIds = JSON.parse(store.local.get(purchaseEventStorageKey));
 
         expect(Object.keys(newOrderIds).length).to.equal(3);
-        expect(newOrderIds[CRC32.str(orderId)]).to.equal(true);
-        expect(newOrderIds[CRC32.str(orderId2)]).to.equal(true);
-        expect(newOrderIds[CRC32.str(orderId3)]).to.equal(true);
+        expect(newOrderIds.includes(CRC32.str(orderId))).to.equal(true);
+        expect(newOrderIds.includes(CRC32.str(orderId2))).to.equal(true);
+        expect(newOrderIds.includes(CRC32.str(orderId3))).to.equal(true);
       });
     });
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -99,7 +99,7 @@ const utils = {
 
   hasOrderIdRecord(orderId) {
     const orderIdHash = CRC32.str(orderId.toString());
-    let purchaseEventStorage = store.session.get(purchaseEventStorageKey);
+    let purchaseEventStorage = store.local.get(purchaseEventStorageKey);
 
     if (typeof purchaseEventStorage === 'string') {
       purchaseEventStorage = JSON.parse(purchaseEventStorage);
@@ -113,7 +113,7 @@ const utils = {
 
   addOrderIdRecord(orderId) {
     const orderIdHash = CRC32.str(orderId.toString());
-    let purchaseEventStorage = store.session.get(purchaseEventStorageKey);
+    let purchaseEventStorage = store.local.get(purchaseEventStorageKey);
 
     if (typeof purchaseEventStorage === 'string') {
       purchaseEventStorage = JSON.parse(purchaseEventStorage);
@@ -133,8 +133,8 @@ const utils = {
       };
     }
 
-    // Push the order id map into session storage
-    store.session.set(purchaseEventStorageKey, JSON.stringify(purchaseEventStorage));
+    // Push the order id map into local storage
+    store.local.set(purchaseEventStorageKey, JSON.stringify(purchaseEventStorage));
   },
 
   // Abort network request based on supplied timeout interval (in milliseconds)

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -121,16 +121,17 @@ const utils = {
 
     if (purchaseEventStorage) {
       // If the order already exists, do nothing
-      if (purchaseEventStorage[orderIdHash]) {
+      if (purchaseEventStorage.includes(orderIdHash)) {
         return;
       }
 
-      purchaseEventStorage[orderIdHash] = true;
+      if (purchaseEventStorage.length >= 10) {
+        purchaseEventStorage.slice(-9);
+      }
+      purchaseEventStorage.push(orderIdHash);
     } else {
       // Create a new object map for the order ids
-      purchaseEventStorage = {
-        [orderIdHash]: true,
-      };
+      purchaseEventStorage = [orderIdHash];
     }
 
     // Push the order id map into local storage

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -104,7 +104,7 @@ const utils = {
     if (typeof purchaseEventStorage === 'string') {
       purchaseEventStorage = JSON.parse(purchaseEventStorage);
     }
-    if (purchaseEventStorage && purchaseEventStorage[orderIdHash]) {
+    if (purchaseEventStorage && purchaseEventStorage.includes(orderIdHash)) {
       return true;
     }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -126,7 +126,7 @@ const utils = {
       }
 
       if (purchaseEventStorage.length >= 10) {
-        purchaseEventStorage.slice(-9);
+        purchaseEventStorage = purchaseEventStorage.slice(-9);
       }
       purchaseEventStorage.push(orderIdHash);
     } else {


### PR DESCRIPTION
This changes the order_id to be stored in local storage instead of session storage so deduplication works across tabs.

Changed the order_id storage to be an array instead of object so that we can limit # of order_ids to 10 in order of time. 

Also fixes some failing tests.