### PR TITLE
[NO-CSL] Update skipNetworkTimeoutTests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,4 +25,4 @@ jobs:
         run: npm run test:all:parallel
         env:
           TEST_API_KEY: ${{ secrets.TEST_API_KEY }}
-          SKIP_NETWORK_TIMEOUT_TESTS: false
+          SKIP_NETWORK_TIMEOUT_TESTS: true

--- a/spec/src/modules/autocomplete.js
+++ b/spec/src/modules/autocomplete.js
@@ -422,7 +422,7 @@ describe(`ConstructorIO - Autocomplete${bundledDescriptionSuffix}`, () => {
       return expect(autocomplete.getAutocompleteResults(query)).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { autocomplete } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/browse.js
+++ b/spec/src/modules/browse.js
@@ -695,7 +695,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
       return expect(browse.getBrowseResults(filterName, filterValue)).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { browse } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -1161,7 +1161,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
       return expect(browse.getBrowseResultsForItemIds(ids)).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { browse } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -1284,7 +1284,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
       return expect(browse.getBrowseGroups()).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { browse } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -1444,7 +1444,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
       return expect(browse.getBrowseFacets()).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { browse } = new ConstructorIO({ apiKey: testApiKey });
 
@@ -1551,7 +1551,7 @@ describe(`ConstructorIO - Browse${bundledDescriptionSuffix}`, () => {
       return expect(browse.getBrowseFacetOptions(facetName)).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { browse } = new ConstructorIO({
           apiKey: testApiKey,

--- a/spec/src/modules/quizzes.js
+++ b/spec/src/modules/quizzes.js
@@ -188,7 +188,7 @@ describe(`ConstructorIO - Quizzes${bundledDescriptionSuffix}`, () => {
       return expect(quizzes.getQuizNextQuestion(validQuizId, { versionId: 'foo' })).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { quizzes } = new ConstructorIO({
           apiKey: quizApiKey,
@@ -365,7 +365,7 @@ describe(`ConstructorIO - Quizzes${bundledDescriptionSuffix}`, () => {
       return expect(quizzes.getQuizResults(validQuizId, { answers: [] })).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { quizzes } = new ConstructorIO({
           apiKey: quizApiKey,

--- a/spec/src/modules/recommendations.js
+++ b/spec/src/modules/recommendations.js
@@ -420,7 +420,7 @@ describe(`ConstructorIO - Recommendations${bundledDescriptionSuffix}`, () => {
       })).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { recommendations } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/search.js
+++ b/spec/src/modules/search.js
@@ -632,7 +632,7 @@ describe(`ConstructorIO - Search${bundledDescriptionSuffix}`, () => {
       return expect(search.getSearchResults(query, { section })).to.eventually.be.rejected;
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', () => {
         const { search } = new ConstructorIO({ apiKey: testApiKey });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -277,7 +277,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackSessionStart()).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -525,7 +525,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackInputFocus()).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -838,7 +838,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackAutocompleteSelect(term, requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -1159,7 +1159,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackItemDetailLoad(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -1410,7 +1410,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackSearchSubmit(term, requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -1808,7 +1808,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackSearchResultsLoaded(term, requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -2284,7 +2284,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackSearchResultClick(term, requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -2869,7 +2869,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackConversion(term, requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -3394,7 +3394,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackPurchase()).to.be.an('error');
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -3746,7 +3746,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackRecommendationView(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -4185,7 +4185,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackRecommendationClick(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -4529,7 +4529,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackBrowseResultsLoaded(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -4969,7 +4969,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,
@@ -5358,7 +5358,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackGenericResultClick(requiredParameters)).to.equal(true);
     });
 
-    if (skipNetworkTimeoutTests) {
+    if (!skipNetworkTimeoutTests) {
       it('Should be rejected when network request timeout is provided and reached', (done) => {
         const { tracker } = new ConstructorIO({
           apiKey: testApiKey,


### PR DESCRIPTION
When we renamed `RUN_NETWORK_TIMEOUT_TESTS` to `SKIP_NETWORK_TIMEOUT_TESTS` we forgot to negate the values. This PR doesn't change anything functionally, just updates the values to align with the variable name.