### PR TITLE
[NOCSL] Add support for item_name in browse click

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1976,7 +1976,6 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       item_id: 'customer-id',
     };
     const legacyParameters = {
-      ...requiredParameters,
       name: 'name',
       customer_id: 'customer-id',
     };
@@ -4658,6 +4657,13 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
       filter_name: 'group_id',
       filter_value: 'BrandXY',
+      item_name: 'Pencil',
+    };
+    const legacyParameters = {
+      filter_name: 'group_id',
+      filter_value: 'BrandXY',
+      name: 'Pencil',
+      customer_id: 'customer-id',
     };
     const optionalParameters = {
       section: 'Products',
@@ -4687,6 +4693,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.item_name);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
@@ -5055,6 +5062,31 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       });
 
       expect(tracker.trackBrowseResultClick(requiredParameters)).to.equal(true);
+    });
+
+    it('Should respond with a valid response when legacy parameters are provided', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('item_id').to.equal(legacyParameters.customer_id);
+        expect(requestParams).to.have.property('item_name').to.equal(legacyParameters.name);
+
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message').to.equal('ok');
+
+        done();
+      });
+
+      expect(tracker.trackBrowseResultClick(legacyParameters)).to.equal(true);
     });
   });
 

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4660,6 +4660,11 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       filter_value: 'BrandXY',
       item_name: 'Pencil',
     };
+    const legacyParameters = {
+      ...requiredParameters,
+      name: 'name',
+      customer_id: 'customer-id',
+    };
     const optionalParameters = {
       section: 'Products',
       result_count: 5,

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4658,6 +4658,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
       filter_name: 'group_id',
       filter_value: 'BrandXY',
+      item_name: 'Pencil',
     };
     const optionalParameters = {
       section: 'Products',
@@ -4687,6 +4688,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
+        expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.item_name);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4658,12 +4658,6 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       item_id: 'product0dbae320-3950-11ea-9251-8dee6d0eb3cd-new',
       filter_name: 'group_id',
       filter_value: 'BrandXY',
-      item_name: 'Pencil',
-    };
-    const legacyParameters = {
-      ...requiredParameters,
-      name: 'name',
-      customer_id: 'customer-id',
     };
     const optionalParameters = {
       section: 'Products',
@@ -4693,7 +4687,6 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.item_id);
-        expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.item_name);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filter_value);
         expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1130,9 +1130,9 @@ class Tracker {
 
       // Ensure support for both item_id and customer_id as parameters
       if (item_id) {
-        bodyParams.customer_id = item_id;
+        bodyParams.item_id = item_id;
       } else if (customer_id) {
-        bodyParams.customer_id = customer_id;
+        bodyParams.item_id = customer_id;
       }
 
       // Ensure support for both item_name and name as parameters

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1082,6 +1082,7 @@ class Tracker {
         filter_value,
         item_id,
         item_name,
+        name,
       } = parameters;
 
       if (section) {
@@ -1132,6 +1133,8 @@ class Tracker {
 
       if (item_name) {
         bodyParams.item_name = item_name;
+      } else if (name) {
+        bodyParams.item_name = name;
       }
 
       const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1081,6 +1081,7 @@ class Tracker {
         filter_name,
         filter_value,
         item_id,
+        customer_id,
         item_name,
         name,
       } = parameters;

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1127,10 +1127,14 @@ class Tracker {
         bodyParams.filter_value = filter_value;
       }
 
+      // Ensure support for both item_id and customer_id as parameters
       if (item_id) {
-        bodyParams.item_id = item_id;
+        bodyParams.customer_id = item_id;
+      } else if (customer_id) {
+        bodyParams.customer_id = customer_id;
       }
 
+      // Ensure support for both item_name and name as parameters
       if (item_name) {
         bodyParams.item_name = item_name;
       } else if (name) {

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1035,6 +1035,7 @@ class Tracker {
    * @param {string} parameters.filter_name - Filter name
    * @param {string} parameters.filter_value - Filter value
    * @param {string} parameters.item_id - Product item unique identifier
+   * @param {string} parameters.item_name - Product item name
    * @param {string} [parameters.section="Products"] - Index section
    * @param {string} [parameters.variation_id] - Product item variation unique identifier
    * @param {string} [parameters.result_id] - Browse result identifier (returned in response from Constructor)
@@ -1080,6 +1081,7 @@ class Tracker {
         filter_name,
         filter_value,
         item_id,
+        item_name,
       } = parameters;
 
       if (section) {
@@ -1126,6 +1128,10 @@ class Tracker {
 
       if (item_id) {
         bodyParams.item_id = item_id;
+      }
+
+      if (item_name) {
+        bodyParams.item_name = item_name;
       }
 
       const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;


### PR DESCRIPTION
Customer does not expose item_ids so need to implement tracking based off of item_name only.