### PR TITLE
[CSL - 2154] Migrate types from Autocomplete UI to Client-Javascript

### DIFF
--- a/src/types/autocomplete.d.ts
+++ b/src/types/autocomplete.d.ts
@@ -1,5 +1,6 @@
 import {
   ConstructorClientOptions,
+  Item,
   NetworkParameters,
   RequestFeature,
   RequestFeatureVariant,
@@ -35,7 +36,7 @@ declare class Autocomplete {
  ********** */
 export interface AutocompleteResponse extends Record<string, any> {
   request: Partial<AutocompleteRequestType>;
-  sections: Record<string, Section>;
+  sections: Record<string, Item[]>;
   result_id: string;
 }
 
@@ -46,14 +47,4 @@ export interface AutocompleteRequestType extends Record<string, any> {
   features: Partial<RequestFeature>;
   feature_variants: Partial<RequestFeatureVariant>;
   searchandized_items: Record<string, any>;
-}
-
-export type Section = Partial<SectionItem>[];
-
-export interface SectionItem extends Record<string, any> {
-  data: Record<string, any>;
-  is_slotted: boolean;
-  labels: Record<string, any>;
-  matched_terms: string[];
-  value: string;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -132,10 +132,10 @@ export interface FacetOption extends Record<string, any> {
 }
 
 export interface Group extends BaseGroup, Record<string, any> {
-  count: number;
-  data: Record<string, any>;
-  parents: BaseGroup[];
-  children: Group[];
+  count?: number;
+  data?: Record<string, any>;
+  parents?: BaseGroup[];
+  children?: Group[];
 }
 
 export interface Collection extends Record<string, any> {
@@ -194,6 +194,7 @@ export interface ItemData extends Record<string, any> {
   id?: string;
   image_url?: string;
   group_ids?: string[];
+  groups?: Group[]
   facets?: Facet[];
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -180,3 +180,44 @@ export type FilterExpressionRange = {
 };
 
 export type FilterExpressionRangeValue = ['-inf' | number, 'inf' | number];
+
+export type Item = Product | SearchSuggestion | ItemBase;
+
+export interface ItemBase extends Record<string, any> {
+  id?: string;
+  url?: string;
+  value?: string;
+  section: string;
+  data?: Record<string, any>;
+}
+
+export type Product = {
+  is_slotted: boolean;
+  labels: Record<string, unknown>;
+  matched_terms: string[];
+  value: string;
+  data: {
+    facets: { name: string; values: string[] }[];
+    group_ids: string[];
+    id: string;
+    image_url: string;
+    price: number;
+    swatchColor: string;
+    url: string;
+    variation_id: string;
+  };
+  section: 'Products';
+};
+
+export type SearchSuggestion = {
+  is_slotted: boolean;
+  labels: Record<string, unknown>;
+  matched_terms: string[];
+  value: string;
+  data: {
+    id: string;
+    url?: string;
+  };
+  section: 'Search Suggestions';
+  id: string;
+};

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -181,43 +181,19 @@ export type FilterExpressionRange = {
 
 export type FilterExpressionRangeValue = ['-inf' | number, 'inf' | number];
 
-export type Item = Product | SearchSuggestion | ItemBase;
-
-export interface ItemBase extends Record<string, any> {
-  id?: string;
-  url?: string;
-  value?: string;
-  section: string;
+export interface Item extends Record<string, any> {
+  value: string;
+  is_slotted: boolean;
+  labels: Record<string, unknown>;
+  matched_terms: string[];
   data?: Record<string, any>;
+  section?: string;
 }
 
-export type Product = {
-  is_slotted: boolean;
-  labels: Record<string, unknown>;
-  matched_terms: string[];
-  value: string;
-  data: {
-    facets: { name: string; values: string[] }[];
-    group_ids: string[];
-    id: string;
-    image_url: string;
-    price: number;
-    swatchColor: string;
-    url: string;
-    variation_id: string;
-  };
+export interface Product extends Item {
   section: 'Products';
-};
+}
 
-export type SearchSuggestion = {
-  is_slotted: boolean;
-  labels: Record<string, unknown>;
-  matched_terms: string[];
-  value: string;
-  data: {
-    id: string;
-    url?: string;
-  };
+export interface SearchSuggestion extends Item {
   section: 'Search Suggestions';
-  id: string;
-};
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -186,8 +186,16 @@ export interface Item extends Record<string, any> {
   is_slotted: boolean;
   labels: Record<string, unknown>;
   matched_terms: string[];
-  data?: Record<string, any>;
+  data?: ItemData;
   section?: string;
+}
+
+export interface ItemData extends Record<string, any> {
+  url?: string;
+  id?: string;
+  image_url?: string;
+  group_ids?: string[];
+  facets?: Facet[];
 }
 
 export interface Product extends Item {
@@ -195,5 +203,8 @@ export interface Product extends Item {
 }
 
 export interface SearchSuggestion extends Item {
+  data?: {
+    total_num_results?: number
+  } & ItemData;
   section: 'Search Suggestions';
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -187,7 +187,6 @@ export interface Item extends Record<string, any> {
   labels: Record<string, unknown>;
   matched_terms: string[];
   data?: ItemData;
-  section?: string;
 }
 
 export interface ItemData extends Record<string, any> {
@@ -199,12 +198,10 @@ export interface ItemData extends Record<string, any> {
 }
 
 export interface Product extends Item {
-  section: 'Products';
 }
 
 export interface SearchSuggestion extends Item {
   data?: {
     total_num_results?: number
   } & ItemData;
-  section: 'Search Suggestions';
 }


### PR DESCRIPTION
Types Migrated: `Item` (formerly ItemBase and Item), `Product` & `Search Suggestions`. Converted them to interfaces to utilize the `extends` keyword as it allows consumers to more easily define their own "Items" based on their own Index Sections.

Could probably drop the `Product` & `Search Suggestions` types since you'd likely want to extend them to define your own data model for the `data` attribute but they're general types that always exists regardless of the index so I included them in.

On the Autocomplete OS UI side of things, we'd do the following:
```
import { Product as BaseProduct } from '@constructor-io/constructorio-client-javascript'

export type ProductData = { ... }
export interface Product extends BaseProduct {
    data: ProductData
}
```

### Possible New Stories:
- Replace client-js' individual SABR modules implementation of `Items` with these types to enforce consistency.