### PR TITLE
Update Package to be Isomorphic (work on both client and Node)

### DIFF
--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -90,20 +90,8 @@ class ConstructorIO {
     let client_id;
     const versionFromGlobal = typeof global !== 'undefined' && global.CLIENT_VERSION;
 
-    // Initialize ID session if DOM context is available
-    if (helpers.canUseDOM()) {
-      ({ session_id, client_id } = new ConstructorioID(idOptions || {}));
-    } else {
-      // Validate session ID is provided
-      if (!sessionId || typeof sessionId !== 'number') {
-        throw new Error('sessionId is a required user parameter of type number');
-      }
-
-      // Validate client ID is provided
-      if (!clientId || typeof clientId !== 'string') {
-        throw new Error('clientId is a required user parameter of type string');
-      }
-    }
+    // Initialize ID session
+    ({ session_id, client_id } = new ConstructorioID(idOptions || {}));
 
     this.options = {
       apiKey,


### PR DESCRIPTION
Hey guys,

Bert from Ashley here. Not really fully intending this PR to be merged but, more spark conversation. Right now we are in the process of converting a lot of our pages to Sveltekit (if you are familiar with Next.js it is pretty similar to that) One of the features of Sveltekit is having page level functions that can run on both the server and the client.  The only down side to this is that it requires clients like this to work on both server and client. Ie isomorphic. There are ways around it but, it complicates things a lot and this package seems extremly close to working on both.

Now experimenting with this package in Sveltekit the only thing that seems to be blocking this package from working is the lines deleted in this PR to get the sessionId, and ClientId with ConstructorIOID. I find this weird as the ConstructorIOID seems to be already Isomorphic having conditions to generate these values on Node and the browser. Is there a reason the API client doesn't want to generate these values on the server? Information on why would be much appreciated. 

At the very least is there anyway I can run the client on node without having to use the specific node package? It just seems really close to working and having to use 2 clients would up the complexity a lot. 

Thanks for your input!

