### PR TITLE
Export all types from index.d.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.35.18",
   "description": "Constructor.io JavaScript client",
   "main": "lib/constructorio.js",
-  "types": "lib/types/constructorio.d.ts",
+  "types": "lib/types/index.d.ts",
   "scripts": {
     "clean": "sudo rm -rf node_modules package-lock.json",
     "version": "npm run verify-node-version && npm run docs && git add ./docs/* && npm run bundle && git add -A ./dist",

--- a/src/types/constructorio.d.ts
+++ b/src/types/constructorio.d.ts
@@ -6,6 +6,8 @@ import Quizzes from './quizzes';
 import Tracker from './tracker';
 import { ConstructorClientOptions } from '.';
 
+export = ConstructorIO;
+
 declare class ConstructorIO {
   constructor(options: ConstructorClientOptions);
 

--- a/src/types/constructorio.d.ts
+++ b/src/types/constructorio.d.ts
@@ -6,8 +6,6 @@ import Quizzes from './quizzes';
 import Tracker from './tracker';
 import { ConstructorClientOptions } from '.';
 
-export = ConstructorIO;
-
 declare class ConstructorIO {
   constructor(options: ConstructorClientOptions);
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -3,7 +3,6 @@ import EventDispatcher from './event-dispatcher';
 import ConstructorIO from './constructorio';
 
 export default ConstructorIO;
-
 export * from './search';
 export * from './autocomplete';
 export * from './quizzes';

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -7,6 +7,7 @@ export * from './recommendations';
 export * from './browse';
 export * from './tracker';
 export * from './event-dispatcher';
+export * from './constructorio';
 
 export interface NetworkParameters extends Record<string, any> {
   timeout?: number;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,5 +1,9 @@
 import EventDispatcher from './event-dispatcher';
 
+import ConstructorIO from './constructorio';
+
+export default ConstructorIO;
+
 export * from './search';
 export * from './autocomplete';
 export * from './quizzes';


### PR DESCRIPTION
Instead of importing types from this path `@constructor-io/constructorio-client-javascript/lib/types ` We will be able to import types from this path `@constructor-io/constructorio-client-javascript`