### PR TITLE
[CSL-2863] Proactive pii detection

### DIFF
--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -5,6 +5,7 @@
   no-unused-expressions,
   max-nested-callbacks,
 */
+/* cspell:disable */
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');
@@ -102,7 +103,6 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         'daniel()*@gmail.com',
         'daniel@%*.com',
         'daniel@tillero@gmail.com',
-        // eslint-disable-next-line @cspell/spellchecker
         'daniel@tillero',
       ],
       phone_number: [

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -32,6 +32,107 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
     const storageKey = '_constructorio_requests';
     const waitInterval = 2000;
     let requestQueueOptions = {};
+    const pii = {
+      email: [
+        'example@constructor.io',
+        'daniel-100@constructor.io',
+        'daniel.100@constructor.io',
+        'daniel111@tillero.com',
+        'daniel+123@psl.info',
+        'daniel-100@tillero.net',
+        'daniel.100@tillero.com.au',
+        'daniel@1.com',
+        'daniel@gmail.com.com',
+        'daniel+100@gmail.com',
+        'daniel-100@constructor-test.io',
+      ],
+      phone_number: [
+        '+12363334011',
+        '+1 236 333 4011',
+        '(236)2228542',
+        '(236) 222 8542',
+        '(236)222-8542',
+        '(236) 222-8542',
+        '+420736447763',
+        '+420 736 447 763',
+      ],
+      credit_card_number: [
+        // Sources of example card numbers:
+        // - https://support.bluesnap.com/docs/test-credit-card-numbers
+        // - https://www.paypalobjects.com/en_GB/vhelp/paypalmanager_help/credit_card_numbers.htm
+        '4155279860457', // Visa
+        '4222222222222', // Visa
+        '4263982640269299', // Visa
+        '4917484589897107', // Visa
+        '4001919257537193', // Visa
+        '4007702835532454', // Visa
+        '4111111111111111', // Visa
+        '4012888888881881', // Visa
+        '5425233430109903', // MasterCard
+        '2222420000001113', // MasterCard
+        '2223000048410010', // MasterCard
+        '5555555555554444', // MasterCard
+        '5105105105105100', // MasterCard
+        '374245455400126', // American Express
+        '378282246310005', // American Express
+        '371449635398431', // American Express
+        '378734493671000', // American Express
+        '6011556448578945', // Discover
+        '6011000991300009', // Discover
+        '6011111111111117', // Discover
+        '6011000990139424', // Discover
+        '3566000020000410', // JCB
+        '3530111333300000', // JCB
+        '3566002020360505', // JCB
+        '30569309025904', // Diners Club
+        '38520000023237', // Diners Club
+      ],
+    };
+
+    // A list of valid examples (not PII)
+    // These terms should be tracked
+    const notPii = {
+      email: [
+        'daniel',
+        'daniel @constructor.io',
+        'daniel@.com.my',
+        'daniel123@gmail.a',
+        'daniel123@.com',
+        'daniel123@.com.com',
+        'daniel()*@gmail.com',
+        'daniel@%*.com',
+        'daniel@tillero@gmail.com',
+        'daniel@tillero',
+      ],
+      phone_number: [
+        '123',
+        '123 456 789',
+        '236 222 5432',
+        '2362225432',
+        '736447763',
+        '736 447 763',
+        '236456789012',
+        '2364567890123',
+      ],
+      credit_card_number: [
+        '1025',
+        '6155279860457',
+        '1234567890',
+        '12345678901',
+        '123456789012',
+        '1234567890123',
+        '1234567890145',
+        '12345678901678',
+        '1234567890167890',
+        '12345678901678901',
+        '123456789016789012',
+        '1234567890167890123',
+        '12345678901678901234',
+        '123456789016789012345',
+        '12345678901678901234567',
+        '123456789016789012345678',
+      ],
+    };
 
     describe('queue', () => {
       let defaultAgent;
@@ -101,6 +202,34 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         expect(RequestQueue.get()).to.be.an('array').length(0);
         expect(store.local.get(storageKey)).to.be.null;
         helpers.triggerUnload();
+      });
+
+      it('Should not add requests to the queue if PII is detected', () => {
+        const requests = new RequestQueue(requestQueueOptions);
+
+        Object.entries(pii).forEach(([, exampleValues]) => {
+          exampleValues.forEach((exampleValue) => {
+            requests.queue(`https://ac.cnstrc.com/autocomplete/${exampleValue}/search?original_query=${exampleValue}&c=ciojs-2.686.3&i=c8a838d3-b7e0-48bd-92f1-81e08f84b9ee&s=5`);
+          });
+        });
+
+        expect(RequestQueue.get()).to.be.an('array').length(0);
+        expect(store.local.get(storageKey)).to.be.null;
+        helpers.triggerUnload();
+      });
+
+      it('Should add requests to the queue if no PII is detected', () => {
+        const requests = new RequestQueue(requestQueueOptions);
+
+        Object.entries(notPii).forEach(([, exampleValues]) => {
+          exampleValues.forEach((exampleValue) => {
+            requests.queue(`https://ac.cnstrc.com/autocomplete/${exampleValue}/search?original_query=${exampleValue}&c=ciojs-2.686.3&i=c8a838d3-b7e0-48bd-92f1-81e08f84b9ee&s=5`);
+          });
+        });
+
+        expect(RequestQueue.get()).to.be.an('array').length(34);
+        helpers.triggerUnload();
+        expect(store.local.get(storageKey)).to.be.an('array').length(34);
       });
 
       it('Should not add requests to the queue if the user is webdriver', () => {

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -25,7 +25,7 @@ const { fetch } = fetchPonyfill({ Promise });
 const bundled = process.env.BUNDLED === 'true';
 const testApiKey = process.env.TEST_REQUEST_API_KEY;
 
-describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
+describe.only('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
   // Don't run tests in bundle context, as these tests are for library internals
   if (!bundled) {
     this.timeout(3000);
@@ -35,17 +35,17 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
     let requestQueueOptions = {};
     const pii = {
       email: [
-        'example@constructor.io',
-        'daniel-100@constructor.io',
-        'daniel.100@constructor.io',
-        'daniel111@tillero.com',
-        'daniel+123@psl.info',
-        'daniel-100@tillero.net',
-        'daniel.100@tillero.com.au',
-        'daniel@1.com',
-        'daniel@gmail.com.com',
-        'daniel+100@gmail.com',
-        'daniel-100@constructor-test.io',
+        'test@test.com',
+        'test-100@test.com',
+        'test.100@test.com',
+        'test@test.com',
+        'test+123@test.info',
+        'test-100@test.net',
+        'test.100@test.com.au',
+        'test@test.io',
+        'test@test.com.com',
+        'test+100@test.com',
+        'test-100@test-test.io',
       ],
       phone_number: [
         '+12363334011',
@@ -94,16 +94,16 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
     // These terms should be tracked
     const notPii = {
       email: [
-        'daniel',
-        'daniel @constructor.io',
-        'daniel@.com.my',
-        'daniel123@gmail.a',
-        'daniel123@.com',
-        'daniel123@.com.com',
-        'daniel()*@gmail.com',
-        'daniel@%*.com',
-        'daniel@tillero@gmail.com',
-        'daniel@tillero',
+        'test',
+        'test @test.io',
+        'test@.com.my',
+        'test123@test.a',
+        'test123@.com',
+        'test123@.com.com',
+        'test()*@test.com',
+        'test@%*.com',
+        'test@test@test.com',
+        'test@test',
       ],
       phone_number: [
         '123',

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -25,7 +25,7 @@ const { fetch } = fetchPonyfill({ Promise });
 const bundled = process.env.BUNDLED === 'true';
 const testApiKey = process.env.TEST_REQUEST_API_KEY;
 
-describe.only('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
+describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
   // Don't run tests in bundle context, as these tests are for library internals
   if (!bundled) {
     this.timeout(3000);

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -102,6 +102,7 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         'daniel()*@gmail.com',
         'daniel@%*.com',
         'daniel@tillero@gmail.com',
+        // eslint-disable-next-line @cspell/spellchecker
         'daniel@tillero',
       ],
       phone_number: [

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -4,6 +4,14 @@ const store = require('./store');
 
 const purchaseEventStorageKey = '_constructorio_purchase_order_ids';
 
+const PII_REGEX = {
+  email: /^[\w\-+\\.]+@([\w-]+\.)+[\w-]{2,4}$/,
+  phoneNumber: /^(?:\+\d{11,12}|\+\d{1,3}\s\d{3}\s\d{3}\s\d{3,4}|\(\d{3}\)\d{7}|\(\d{3}\)\s\d{3}\s\d{4}|\(\d{3}\)\d{3}-\d{4}|\(\d{3}\)\s\d{3}-\d{4})$/,
+  creditCard:
+    /^(?:4[0-9]{12}(?:[0-9]{3})?|(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})$/, // Visa, Mastercard, Amex, Discover, JCB and Diners Club, regex source: https://www.regular-expressions.info/creditcard.html
+  // Add more PII REGEX
+};
+
 const utils = {
   trimNonBreakingSpaces: (string) => string.replace(/\s/g, ' ').trim(),
 
@@ -194,6 +202,31 @@ const utils = {
         : camelCasedObj[key];
     });
     return snakeCasedObj;
+  },
+  containsPii(query) {
+    const piiRegex = Object.values(PII_REGEX);
+    const normalizedTerm = query.toLowerCase();
+
+    return piiRegex.some((regex) => regex.test(normalizedTerm));
+  },
+  requestContainsPii(urlString) {
+    try {
+      const url = new URL(urlString);
+      const paths = decodeURI(url?.pathname)?.split('/');
+      const paramValues = decodeURIComponent(url?.search)?.split('&').map((param) => param?.split('=')?.[1]);
+
+      if (paths.some((path) => utils.containsPii(path))) {
+        return true;
+      }
+
+      if (paramValues.some((value) => utils.containsPii(value))) {
+        return true;
+      }
+    } catch (e) {
+      // do nothing
+    }
+
+    return false;
   },
 };
 

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -2,6 +2,7 @@
 const store = require('./store');
 const HumanityCheck = require('./humanity-check');
 const helpers = require('./helpers');
+const { requestContainsPii } = require('./helpers');
 
 const storageKey = '_constructorio_requests';
 const requestTTL = 180000; // 3 minutes in milliseconds
@@ -32,6 +33,11 @@ class RequestQueue {
   queue(url, method = 'GET', body = {}, networkParameters = {}) {
     if (this.sendTrackingEvents && !this.humanity.isBot()) {
       const queue = RequestQueue.get();
+
+      if (requestContainsPii(url, body)) {
+        console.log(requestContainsPii(url, body));
+        return;
+      }
 
       queue.push({
         url,

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -35,7 +35,6 @@ class RequestQueue {
       const queue = RequestQueue.get();
 
       if (requestContainsPii(url, body)) {
-        console.log(requestContainsPii(url, body));
         return;
       }
 

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -32,11 +32,11 @@ class RequestQueue {
   // Add request to queue to be dispatched
   queue(url, method = 'GET', body = {}, networkParameters = {}) {
     if (this.sendTrackingEvents && !this.humanity.isBot()) {
-      const queue = RequestQueue.get();
-
       if (requestContainsPii(url, body)) {
         return;
       }
+
+      const queue = RequestQueue.get();
 
       queue.push({
         url,


### PR DESCRIPTION
Since all of our tracking requests go through the request queue, added logic in the request queue to not add a request to queue if PII is detected. Only the path, query parameters are checked at the moment.