### PR TITLE
[CSL-3045] Added enforcement of https for service client url

### DIFF
--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -84,18 +84,12 @@ describe(`ConstructorIO${bundledDescriptionSuffix}`, () => {
   it('Should return an instance with correct serviceUrl when a http serviceUrl is passed', () => {
     const clientId = 'client-id';
     const sessionId = 'session-id';
-    const serviceUrl = 'https://constructor.io';
-    const quizzesServiceUrl = 'http://quizzes.constructor.io';
-    const version = 'custom-version';
-    const networkParameters = { timeout: 5000 };
+    const serviceUrl = 'http://constructor.io';
     const instance = new ConstructorIO({
       apiKey: validApiKey,
       clientId,
       sessionId,
       serviceUrl,
-      quizzesServiceUrl,
-      version,
-      networkParameters,
     });
 
     expect(instance).to.be.an('object');

--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -58,7 +58,7 @@ describe(`ConstructorIO${bundledDescriptionSuffix}`, () => {
   it('Should return an instance with custom options when valid API key is provided', () => {
     const clientId = 'client-id';
     const sessionId = 'session-id';
-    const serviceUrl = 'http://constructor.io';
+    const serviceUrl = 'https://constructor.io';
     const quizzesServiceUrl = 'http://quizzes.constructor.io';
     const version = 'custom-version';
     const networkParameters = { timeout: 5000 };
@@ -79,6 +79,27 @@ describe(`ConstructorIO${bundledDescriptionSuffix}`, () => {
     expect(instance.options).to.have.property('quizzesServiceUrl').to.equal(quizzesServiceUrl);
     expect(instance.options).to.have.property('version').to.equal(version);
     expect(instance.options).to.have.property('networkParameters').to.equal(networkParameters);
+  });
+
+  it('Should return an instance with correct serviceUrl when a http serviceUrl is passed', () => {
+    const clientId = 'client-id';
+    const sessionId = 'session-id';
+    const serviceUrl = 'https://constructor.io';
+    const quizzesServiceUrl = 'http://quizzes.constructor.io';
+    const version = 'custom-version';
+    const networkParameters = { timeout: 5000 };
+    const instance = new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+      sessionId,
+      serviceUrl,
+      quizzesServiceUrl,
+      version,
+      networkParameters,
+    });
+
+    expect(instance).to.be.an('object');
+    expect(instance.options).to.have.property('serviceUrl').to.equal('https://constructor.io');
   });
 
   it('Should remove any trailing slashes from the serviceUrl', () => {

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -20,6 +20,7 @@ const {
   addOrderIdRecord,
   applyNetworkTimeout,
   stringify,
+  addHTTPSToString,
 } = require('../../../test/utils/helpers'); // eslint-disable-line import/extensions
 const jsdom = require('./jsdom-global');
 const store = require('../../../test/utils/store'); // eslint-disable-line import/extensions
@@ -400,6 +401,34 @@ describe('ConstructorIO - Utils - Helpers', () => {
         const stringified = stringify(obj);
 
         expect(stringified).to.equal('a=1&b=1%2C2&c=2&c=3&d=true&d=false&e%5Bf%5D=g&e%5Bf%5D=h');
+      });
+    });
+
+    describe('addHTTPSToString', () => {
+      it('Should return the url without any modification', () => {
+        const testUrl = 'https://www.constructor.io';
+
+        expect(addHTTPSToString(testUrl)).to.equal(testUrl);
+      });
+
+      it('Should return url with no protocol with https at the beginning', () => {
+        const testUrl = 'www.constructor.io';
+        const expectedUrl = 'https://www.constructor.io';
+
+        expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
+      });
+
+      it('Should return url with an http protocol with https at the beginning', () => {
+        const testUrl = 'http://www.constructor.io';
+        const expectedUrl = 'https://www.constructor.io';
+
+        expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
+      });
+
+      it('Should return null if param is not a string', () => {
+        const testUrl = {};
+
+        expect(addHTTPSToString(testUrl)).to.equal(null);
       });
     });
   }

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -105,10 +105,12 @@ class ConstructorIO {
       }
     }
 
+    const normalizedServiceUrl = serviceUrl && serviceUrl.replace(/\/$/, '');
+
     this.options = {
       apiKey,
       version: versionFromOptions || versionFromGlobal || computePackageVersion(),
-      serviceUrl: (serviceUrl && serviceUrl.replace(/\/$/, '')) || 'https://ac.cnstrc.com',
+      serviceUrl: helpers.addHTTPSToString(normalizedServiceUrl) || 'https://ac.cnstrc.com',
       quizzesServiceUrl: (quizzesServiceUrl && quizzesServiceUrl.replace(/\/$/, '')) || 'https://quizzes.cnstrc.com',
       sessionId: sessionId || session_id,
       clientId: clientId || client_id,

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -238,6 +238,27 @@ const utils = {
 
     return obfuscatedUrl;
   },
+
+  addHTTPSToString(url) {
+    if (typeof url !== 'string') {
+      return null;
+    }
+
+    const doesUrlIncludeHTTPS = url.startsWith('https://');
+    const doesUrlStartWithHTTP = url.startsWith('http://');
+
+    if (!doesUrlIncludeHTTPS && doesUrlStartWithHTTP) {
+      return url.replace('http', 'https');
+    }
+
+    if (!doesUrlStartWithHTTP && !doesUrlIncludeHTTPS) {
+      const urlWithHttps = `https://${url}`;
+
+      return urlWithHttps;
+    }
+
+    return url;
+  },
 };
 
 module.exports = utils;


### PR DESCRIPTION
This PR enforces HTTPs for the Service Url, similarly to what was done for the Node client in this [PR](https://github.com/Constructor-io/constructorio-node/pull/193)