### PR TITLE
[CI-3437] Allows Purchases with the same orderId to be tracked for different keys

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4118,12 +4118,14 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
           fetch: fetchSpy,
           ...requestQueueOptions,
         });
+        const orderId = '848291039';
+        const apiKey = testApiKey;
 
-        addOrderIdRecord('848291039');
+        addOrderIdRecord({ orderId, apiKey });
 
         expect(tracker.trackPurchase(Object.assign(requiredParameters, {
           ...optionalParameters,
-          orderId: '848291039',
+          orderId,
         }))).to.equal(false);
 
         setTimeout(() => {
@@ -4158,8 +4160,8 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         done();
       });
 
-      addOrderIdRecord('239402919');
-      addOrderIdRecord('482039192');
+      addOrderIdRecord({ orderId: '239402919', apiKey: testApiKey });
+      addOrderIdRecord({ orderId: '482039192', apiKey: testApiKey });
 
       expect(tracker.trackPurchase(Object.assign(requiredParameters, {
         ...optionalParameters,

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -254,11 +254,15 @@ describe('ConstructorIO - Utils - Helpers', () => {
       it('Should return true if the order id already exists from a previous purchase event', () => {
         store.local.set(purchaseEventStorageKey, [CRC32.str(orderId)]);
 
-        expect(hasOrderIdRecord(orderId)).to.equal(true);
+        expect(hasOrderIdRecord({ orderId })).to.equal(true);
       });
 
       it('Should return null if the order id does not already exist', () => {
-        expect(hasOrderIdRecord(orderId)).to.equal(null);
+        expect(hasOrderIdRecord({ orderId })).to.equal(null);
+      });
+
+      it('Should return true if the order id is repeated but for a different apiKey', () => {
+        expect(hasOrderIdRecord({ orderId, apiKey: 'test-key' })).to.equal(true);
       });
     });
 
@@ -275,7 +279,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
-        addOrderIdRecord(orderId);
+        addOrderIdRecord({ orderId });
         const newOrderIds = store.local.get(purchaseEventStorageKey);
         const newOrderIdExists = newOrderIds.includes(CRC32.str(orderId));
 
@@ -290,7 +294,7 @@ describe('ConstructorIO - Utils - Helpers', () => {
         orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.eql([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]);
 
-        addOrderIdRecord(orderId);
+        addOrderIdRecord({ orderId });
         const newOrderIds = store.local.get(purchaseEventStorageKey);
 
         expect(newOrderIds).to.eql([3, 4, 5, 6, 7, 8, 9, 10, 11, CRC32.str(orderId)]);
@@ -300,8 +304,8 @@ describe('ConstructorIO - Utils - Helpers', () => {
         const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
-        addOrderIdRecord(orderId);
-        addOrderIdRecord(orderId);
+        addOrderIdRecord({ orderId });
+        addOrderIdRecord({ orderId });
         const newOrderIds = store.local.get(purchaseEventStorageKey);
         const newOrderIdExists = newOrderIds.includes(CRC32.str(orderId));
 
@@ -309,13 +313,27 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(newOrderIdExists).to.equal(true);
       });
 
+      it('Should allow adding of duplicate order ids for different keys to the purchase event storage', () => {
+        const orderIds = store.local.get(purchaseEventStorageKey);
+        const apiKey1 = 'test-key-1';
+        const apiKey2 = 'test-key-2';
+
+        expect(orderIds).to.equal(null);
+
+        addOrderIdRecord({ orderId, apiKey1 });
+        addOrderIdRecord({ orderId, apiKey2 });
+        const newOrderIds = store.local.get(purchaseEventStorageKey);
+
+        expect(newOrderIds.length).to.equal(2);
+      });
+
       it('Should keep a history of order ids', () => {
         const orderIds = store.local.get(purchaseEventStorageKey);
         expect(orderIds).to.equal(null);
 
-        addOrderIdRecord(orderId);
-        addOrderIdRecord(orderId2);
-        addOrderIdRecord(orderId3);
+        addOrderIdRecord({ orderId });
+        addOrderIdRecord({ orderId: orderId2 });
+        addOrderIdRecord({ orderId: orderId3 });
         const newOrderIds = store.local.get(purchaseEventStorageKey);
 
         expect(Object.keys(newOrderIds).length).to.equal(3);

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -253,7 +253,6 @@ describe('ConstructorIO - Utils - Helpers', () => {
 
       it('Should return true if the order id already exists from a previous purchase event', () => {
         store.local.set(purchaseEventStorageKey, [CRC32.str(orderId)]);
-
         expect(hasOrderIdRecord({ orderId })).to.equal(true);
       });
 
@@ -261,7 +260,12 @@ describe('ConstructorIO - Utils - Helpers', () => {
         expect(hasOrderIdRecord({ orderId })).to.equal(null);
       });
 
+      it('Should return null if the order id is repeated but for a different apiKey', () => {
+        expect(hasOrderIdRecord({ orderId, apiKey: 'test-key' })).to.equal(null);
+      });
+
       it('Should return true if the order id is repeated but for a different apiKey', () => {
+        store.local.set(purchaseEventStorageKey, [CRC32.str(`test-key-${orderId}`)]);
         expect(hasOrderIdRecord({ orderId, apiKey: 'test-key' })).to.equal(true);
       });
     });
@@ -320,8 +324,8 @@ describe('ConstructorIO - Utils - Helpers', () => {
 
         expect(orderIds).to.equal(null);
 
-        addOrderIdRecord({ orderId, apiKey1 });
-        addOrderIdRecord({ orderId, apiKey2 });
+        addOrderIdRecord({ orderId, apiKey: apiKey1 });
+        addOrderIdRecord({ orderId, apiKey: apiKey2 });
         const newOrderIds = store.local.get(purchaseEventStorageKey);
 
         expect(newOrderIds.length).to.equal(2);

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1125,14 +1125,15 @@ class Tracker {
         section,
         analyticsTags,
       } = parameters;
+      const { apiKey } = this.options;
 
       if (orderId) {
-        // Don't send another purchase event if we have already tracked the order
-        if (helpers.hasOrderIdRecord(orderId)) {
+        // Don't send another purchase event if we have already tracked the order for the current key
+        if (helpers.hasOrderIdRecord({ orderId, apiKey })) {
           return false;
         }
 
-        helpers.addOrderIdRecord(orderId);
+        helpers.addOrderIdRecord({ orderId, apiKey });
 
         // Add order_id to the tracking params
         bodyParams.order_id = orderId;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -113,8 +113,11 @@ const utils = {
     return null;
   },
 
-  hasOrderIdRecord(orderId) {
-    const orderIdHash = CRC32.str(orderId.toString());
+  hasOrderIdRecord({ orderId, apiKey }) {
+    let orderPerKeyId = orderId;
+    if (apiKey) orderPerKeyId = `${apiKey}-${orderId}`;
+
+    const orderIdHash = CRC32.str(orderPerKeyId.toString());
     let purchaseEventStorage = store.local.get(purchaseEventStorageKey);
 
     if (typeof purchaseEventStorage === 'string') {
@@ -127,8 +130,11 @@ const utils = {
     return null;
   },
 
-  addOrderIdRecord(orderId) {
-    const orderIdHash = CRC32.str(orderId.toString());
+  addOrderIdRecord({ orderId, apiKey }) {
+    let orderPerKeyId = orderId;
+    if (apiKey) orderPerKeyId = `${apiKey}-${orderId}`;
+
+    const orderIdHash = CRC32.str(orderPerKeyId.toString());
     let purchaseEventStorage = store.local.get(purchaseEventStorageKey);
 
     if (typeof purchaseEventStorage === 'string') {


### PR DESCRIPTION
Gap has a single-cart system for multiple brands. This means we need to fire multiple purchase events on the beacon with the same orderId but to different keys. The current implementation prevents that, so I extended it to make it more flexible.

```
// previously
hasOrderId(orderId)

// now
hasOrderId({ orderId, apiKey })
hasOrderId({ orderId }) // also works
```