### PR TITLE
obfuscate PII from request url params and query params

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -1901,7 +1901,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
     it('Should properly obfuscate PII in a path parameter', (done) => {
       const termWithPII = ' test-email@gmail.com';
-      const replaceBy = '<email_omitted>';
+      const replaceWith = '<email_omitted>';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1913,7 +1913,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestUrl).to.include(replaceBy);
+        expect(requestUrl).to.include(replaceWith);
         expect(requestUrl).to.not.include(termWithPII);
 
         // Response
@@ -1928,7 +1928,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
     it('Should properly obfuscate PII in a query parameter', (done) => {
       const termWithPII = ' test-email@gmail.com';
-      const replaceBy = '<email_omitted>';
+      const replaceWith = '<email_omitted>';
       const { tracker } = new ConstructorIO({
         apiKey: testApiKey,
         fetch: fetchSpy,
@@ -1940,7 +1940,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('original_query').to.equal(replaceBy);
+        expect(requestParams).to.have.property('original_query').to.equal(replaceWith);
         expect(requestParams).to.have.property('original_query').to.not.include(termWithPII);
 
         // Response

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -4,6 +4,7 @@
   import/no-unresolved,
   no-unused-expressions,
   max-nested-callbacks,
+  import/extensions
 */
 /* cspell:disable */
 const dotenv = require('dotenv');
@@ -14,7 +15,7 @@ const sinonChai = require('sinon-chai');
 const fetchPonyfill = require('fetch-ponyfill');
 const store = require('../../../test/utils/store');
 const utilsHelpers = require('../../../test/utils/helpers');
-const RequestQueue = require('../../../test/utils/request-queue'); // eslint-disable-line import/extensions
+const RequestQueue = require('../../../test/utils/request-queue');
 const helpers = require('../../mocha.helpers');
 const jsdom = require('./jsdom-global');
 

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -55,7 +55,7 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
           'text test.100@test.io text',
           'test@test@test.com', // This string includes a valid email - test@test.com
         ],
-        replaceBy: '<email_omitted>',
+        replaceWith: '<email_omitted>',
       },
       // Phone Number
       {
@@ -69,7 +69,7 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
           '+420736447763',
           '+420 736 447 763',
         ],
-        replaceBy: '<phone_omitted>',
+        replaceWith: '<phone_omitted>',
       },
       // Credit Card
       {
@@ -102,7 +102,7 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
           '30569309025904', // Diners Club
           '38520000023237', // Diners Club
         ],
-        replaceBy: '<credit_omitted>',
+        replaceWith: '<credit_omitted>',
       },
     ];
 
@@ -225,7 +225,7 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
 
         piiExamples.forEach((example) => {
           example.queries.forEach((query) => {
-            allExamples.push({ query, replaceBy: example.replaceBy });
+            allExamples.push({ query, replaceWith: example.replaceWith });
           });
         });
 
@@ -242,8 +242,8 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
 
         const queue = RequestQueue.get();
 
-        allExamples.forEach(({ replaceBy }, index) => {
-          const expected = `${endpoint}/${replaceBy}/search?original_query=${replaceBy}&${otherQueryParams}`;
+        allExamples.forEach(({ replaceWith }, index) => {
+          const expected = `${endpoint}/${replaceWith}/search?original_query=${replaceWith}&${otherQueryParams}`;
           expect(queue[index].url).to.equal(expected);
         });
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -23,7 +23,7 @@ const PII_REGEX = [
 const utils = {
   trimNonBreakingSpaces: (string) => string.replace(/\s/g, ' ').trim(),
 
-  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent
+  // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986
   encodeURIComponentRFC3986: (string) => encodeURIComponent(string).replace(/[!'()*]/g, (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`),
 
   cleanParams: (paramsObj) => {
@@ -226,16 +226,22 @@ const utils = {
 
     try {
       const url = new URL(urlString);
-      const paths = decodeURI(url?.pathname)?.split('/');
-      const paramValues = decodeURIComponent(url?.search)?.split('&').map((param) => param?.split('=')?.[1]);
+      const paths = url?.pathname?.split('/');
+      const paramValues = url?.search?.split('&')?.map((param) => param.split('=')?.[1]);
 
-      PII_REGEX.forEach((regex) => {
+      PII_REGEX.forEach(({ pattern, replaceBy }) => {
         paths.forEach((path) => {
-          if (utils.containsPii(path, regex.pattern)) obfuscatedUrl = obfuscatedUrl.replaceAll(path, regex.replaceBy);
+          const decodedPath = decodeURIComponent(path);
+          if (utils.containsPii(decodedPath, pattern)) {
+            obfuscatedUrl = obfuscatedUrl.replaceAll(path, replaceBy);
+          }
         });
 
-        paramValues.forEach((param) => {
-          if (utils.containsPii(param, regex.pattern)) obfuscatedUrl = obfuscatedUrl.replaceAll(param, regex.replaceBy);
+        paramValues.forEach((paramValue) => {
+          const decodedParamValue = decodeURIComponent(paramValue);
+          if (utils.containsPii(decodedParamValue, pattern)) {
+            obfuscatedUrl = obfuscatedUrl.replaceAll(decodedParamValue, replaceBy);
+          }
         });
       });
     } catch (e) {

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -7,15 +7,15 @@ const purchaseEventStorageKey = '_constructorio_purchase_order_ids';
 const PII_REGEX = [
   {
     pattern: /[\w\-+\\.]+@([\w-]+\.)+[\w-]{2,4}/,
-    replaceBy: '<email_omitted>',
+    replaceWith: '<email_omitted>',
   },
   {
     pattern: /^(?:\+\d{11,12}|\+\d{1,3}\s\d{3}\s\d{3}\s\d{3,4}|\(\d{3}\)\d{7}|\(\d{3}\)\s\d{3}\s\d{4}|\(\d{3}\)\d{3}-\d{4}|\(\d{3}\)\s\d{3}-\d{4})$/,
-    replaceBy: '<phone_omitted>',
+    replaceWith: '<phone_omitted>',
   },
   {
     pattern: /^(?:4[0-9]{15}|(?:5[1-5][0-9]{2}|222[1-9]|22[3-9][0-9]|2[3-6][0-9]{2}|27[01][0-9]|2720)[0-9]{12}|3[47][0-9]{13}|3(?:0[0-5]|[68][0-9])[0-9]{11}|6(?:011|5[0-9]{2})[0-9]{12}|(?:2131|1800|35\d{3})\d{11})$/, // Visa, Mastercard, Amex, Discover, JCB and Diners Club, regex source: https://www.regular-expressions.info/creditcard.html
-    replaceBy: '<credit_omitted>',
+    replaceWith: '<credit_omitted>',
   },
   // Add more PII REGEX
 ];
@@ -229,18 +229,18 @@ const utils = {
       const paths = url?.pathname?.split('/');
       const paramValues = url?.search?.split('&')?.map((param) => param.split('=')?.[1]);
 
-      PII_REGEX.forEach(({ pattern, replaceBy }) => {
+      PII_REGEX.forEach(({ pattern, replaceWith }) => {
         paths.forEach((path) => {
           const decodedPath = decodeURIComponent(path);
           if (utils.containsPii(decodedPath, pattern)) {
-            obfuscatedUrl = obfuscatedUrl.replaceAll(path, replaceBy);
+            obfuscatedUrl = obfuscatedUrl.replaceAll(path, replaceWith);
           }
         });
 
         paramValues.forEach((paramValue) => {
           const decodedParamValue = decodeURIComponent(paramValue);
           if (utils.containsPii(decodedParamValue, pattern)) {
-            obfuscatedUrl = obfuscatedUrl.replaceAll(decodedParamValue, replaceBy);
+            obfuscatedUrl = obfuscatedUrl.replaceAll(decodedParamValue, replaceWith);
           }
         });
       });


### PR DESCRIPTION
- fine tune our `obfuscatePiiRequest` logic for use in our request queue module
- add some new PII obfuscation tests for our `tracker.trackSearchSubmit`
- to ensure that url encoding & decoding patterns work nicely with PII obfuscation in the request queue
