### PR TITLE
[NOCI] Update strategyId type

### DIFF
--- a/src/types/tracker.d.ts
+++ b/src/types/tracker.d.ts
@@ -141,7 +141,7 @@ declare class Tracker {
   trackRecommendationClick(
     parameters: {
       podId: string;
-      strategyId: string;
+      strategyId?: string;
       itemId: string;
       itemName: string;
       variationId?: string;


### PR DESCRIPTION
Since Item's `strategy` can be undefined, the `strategyId` needs to support undefined to support the types in the os autocomplete-ui