### PR TITLE
[CI-3913] Check for status of local storage in storage helpers.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "2.54.0",
       "license": "MIT",
       "dependencies": {
-        "@constructor-io/constructorio-id": "^2.4.17",
+        "@constructor-io/constructorio-id": "^2.6.0",
         "crc-32": "^1.2.2"
       },
       "devDependencies": {
@@ -1842,9 +1842,9 @@
       }
     },
     "node_modules/@constructor-io/constructorio-id": {
-      "version": "2.4.17",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-id/-/constructorio-id-2.4.17.tgz",
-      "integrity": "sha512-4g5oiDBheUhkqlk1GvRFqQaiCjZJxjifddrcBxICV/uwQr9RzIwZMYEVu1lGuO0KGrhC04m1SBTMibT4hRE3pQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-id/-/constructorio-id-2.6.0.tgz",
+      "integrity": "sha512-2cH68qTHm5qkfmR7tUCtMIsZo4BgIH09CPWyzWYG5qhMkDLL+jSpVFZP016cP7O1Besl39z2GCI3AcVURjmjqQ=="
     },
     "node_modules/@cspell/cspell-bundled-dicts": {
       "version": "6.31.1",
@@ -11141,9 +11141,9 @@
       }
     },
     "@constructor-io/constructorio-id": {
-      "version": "2.4.17",
-      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-id/-/constructorio-id-2.4.17.tgz",
-      "integrity": "sha512-4g5oiDBheUhkqlk1GvRFqQaiCjZJxjifddrcBxICV/uwQr9RzIwZMYEVu1lGuO0KGrhC04m1SBTMibT4hRE3pQ=="
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@constructor-io/constructorio-id/-/constructorio-id-2.6.0.tgz",
+      "integrity": "sha512-2cH68qTHm5qkfmR7tUCtMIsZo4BgIH09CPWyzWYG5qhMkDLL+jSpVFZP016cP7O1Besl39z2GCI3AcVURjmjqQ=="
     },
     "@cspell/cspell-bundled-dicts": {
       "version": "6.31.1",

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "web-streams-polyfill": "^4.0.0"
   },
   "dependencies": {
-    "@constructor-io/constructorio-id": "^2.4.17",
+    "@constructor-io/constructorio-id": "^2.6.0",
     "crc-32": "^1.2.2"
   },
   "peerDependencies": {

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -57,7 +57,7 @@ const session = {
       delete this.overflow[key];
     }
 
-    if (!canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem(key);
     }
   },
@@ -89,7 +89,7 @@ const session = {
   clear() {
     this.overflow = {};
 
-    if (!canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.clear();
     }
   },
@@ -134,7 +134,7 @@ const local = {
       delete this.overflow[key];
     }
 
-    if (!canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.removeItem(key);
     }
   },
@@ -166,7 +166,7 @@ const local = {
   clear() {
     this.overflow = {};
 
-    if (!canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.clear();
     }
   },

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -27,7 +27,7 @@ const session = {
       return valueFromOverflow;
     }
 
-    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
+    if (!canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return null;
     }
 
@@ -57,12 +57,12 @@ const session = {
       delete this.overflow[key];
     }
 
-    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
+    if (!canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem(key);
     }
   },
   key(i) {
-    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
+    if (!canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return Object.keys(this.overflow)?.[i];
     }
 
@@ -80,7 +80,7 @@ const session = {
   length() {
     const overflowLength = Object.keys(this.overflow).length;
 
-    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
+    if (!canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return overflowLength;
     }
 
@@ -89,7 +89,7 @@ const session = {
   clear() {
     this.overflow = {};
 
-    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
+    if (!canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.clear();
     }
   },
@@ -105,7 +105,7 @@ const local = {
       return valueFromOverflow;
     }
 
-    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
+    if (!canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return null;
     }
     const valueFromLocal = localStorage.getItem(key);
@@ -134,12 +134,12 @@ const local = {
       delete this.overflow[key];
     }
 
-    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
+    if (!canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.removeItem(key);
     }
   },
   key(i) {
-    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
+    if (!canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return Object.keys(this.overflow)?.[i];
     }
 
@@ -157,7 +157,7 @@ const local = {
   length() {
     const overflowLength = Object.keys(this.overflow).length;
 
-    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
+    if (!canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return overflowLength;
     }
 
@@ -166,7 +166,7 @@ const local = {
   clear() {
     this.overflow = {};
 
-    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
+    if (!canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.clear();
     }
   },

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -175,6 +175,7 @@ const local = {
 const store = {
   local,
   session,
+  canUseStorage,
 };
 
 module.exports = store;

--- a/src/utils/store.js
+++ b/src/utils/store.js
@@ -1,3 +1,22 @@
+function canUseStorage(type) {
+  let storage;
+  try {
+    storage = window[type];
+    const x = '__storage_test__';
+    storage.setItem(x, x);
+    storage.removeItem(x);
+    return true;
+  } catch (e) {
+    return (
+      e instanceof DOMException
+      && e.name === 'QuotaExceededError'
+      // acknowledge QuotaExceededError only if there's something already stored
+      && storage
+      && storage.length !== 0
+    );
+  }
+}
+
 const session = {
   overflow: {},
   get(key) {
@@ -8,7 +27,7 @@ const session = {
       return valueFromOverflow;
     }
 
-    if (typeof sessionStorage === 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return null;
     }
 
@@ -38,12 +57,12 @@ const session = {
       delete this.overflow[key];
     }
 
-    if (typeof sessionStorage !== 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.removeItem(key);
     }
   },
   key(i) {
-    if (typeof sessionStorage === 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return Object.keys(this.overflow)?.[i];
     }
 
@@ -61,7 +80,7 @@ const session = {
   length() {
     const overflowLength = Object.keys(this.overflow).length;
 
-    if (typeof sessionStorage === 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage === 'undefined') {
       return overflowLength;
     }
 
@@ -70,7 +89,7 @@ const session = {
   clear() {
     this.overflow = {};
 
-    if (typeof sessionStorage !== 'undefined') {
+    if (canUseStorage('sessionStorage') || typeof sessionStorage !== 'undefined') {
       sessionStorage.clear();
     }
   },
@@ -86,7 +105,7 @@ const local = {
       return valueFromOverflow;
     }
 
-    if (typeof localStorage === 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return null;
     }
     const valueFromLocal = localStorage.getItem(key);
@@ -115,12 +134,12 @@ const local = {
       delete this.overflow[key];
     }
 
-    if (typeof localStorage !== 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.removeItem(key);
     }
   },
   key(i) {
-    if (typeof localStorage === 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return Object.keys(this.overflow)?.[i];
     }
 
@@ -138,7 +157,7 @@ const local = {
   length() {
     const overflowLength = Object.keys(this.overflow).length;
 
-    if (typeof localStorage === 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage === 'undefined') {
       return overflowLength;
     }
 
@@ -147,7 +166,7 @@ const local = {
   clear() {
     this.overflow = {};
 
-    if (typeof localStorage !== 'undefined') {
+    if (canUseStorage('localStorage') || typeof localStorage !== 'undefined') {
       localStorage.clear();
     }
   },


### PR DESCRIPTION
Adds a function to check if local storage is accessible before we try to access it.

In browsers that have cookies entirely disabled, localStorage, sessionStorage also become inaccessible. Even accessing the variable will throw an exception "This operation is insecure".

This change ensures that we can use storage before we attempt to access it.