### PR TITLE
[NOCI] Update bot checking logic

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -47,5 +47,6 @@
     "rerank",
     "atcs",
     "testdata",
+    "Bytespider"
   ]
 }

--- a/spec/src/utils/humanity-check.js
+++ b/spec/src/utils/humanity-check.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-underscore-dangle */
+/* eslint-disable no-restricted-properties */
 /* eslint-disable import/no-unresolved */
 const dotenv = require('dotenv');
 const chai = require('chai');
@@ -60,35 +62,72 @@ describe('ConstructorIO - Utils - Humanity Check', () => {
     describe('isBot', () => {
       const storageKey = '_constructorio_is_human';
       let cleanup;
+      let defaultAgent;
 
       beforeEach(() => {
         global.CLIENT_VERSION = 'cio-mocha';
-
         cleanup = jsdom();
-        window.navigator.webdriver = true;
+
+        defaultAgent = window.navigator.userAgent;
       });
 
       afterEach(() => {
         delete global.CLIENT_VERSION;
+        delete window.navigator.webdriver;
+        window.navigator.__defineGetter__('userAgent', () => defaultAgent);
         cleanup();
 
         helpers.clearStorage();
       });
 
-      it('Should have isBot flag set on initial instantiation', () => {
+      it('Should return true if it detects a webdriver', () => {
+        window.navigator.webdriver = true;
         const humanity = new HumanityCheck();
 
         expect(humanity.isBot()).to.equal(true);
         expect(store.session.get(storageKey)).to.equal(null);
       });
 
-      it('Should have isBot flag set to false if session variable is set', () => {
+      it('Should return true if it detects a webdriver and the session variable is set', () => {
+        window.navigator.webdriver = true;
+        const humanity = new HumanityCheck();
+
+        expect(humanity.isBot()).to.equal(true);
+        store.session.set(storageKey, true);
+        expect(humanity.isBot()).to.equal(true);
+        expect(store.session.get(storageKey)).to.equal(true);
+      });
+
+      it('Should return true if it detects a bot user agent', () => {
+        window.navigator.__defineGetter__('userAgent', () => 'Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)');
+        const humanity = new HumanityCheck();
+
+        expect(humanity.isBot()).to.equal(true);
+        expect(store.session.get(storageKey)).to.equal(null);
+      });
+
+      it('Should return true if it detects a bot user agent and the session variable is set', () => {
+        window.navigator.__defineGetter__('userAgent', () => 'Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)');
+        const humanity = new HumanityCheck();
+
+        expect(humanity.isBot()).to.equal(true);
+        store.session.set(storageKey, true);
+        expect(humanity.isBot()).to.equal(true);
+        expect(store.session.get(storageKey)).to.equal(true);
+      });
+
+      it('Should return true if it does not detect the user is a bot user nor webdriver and the session variable has not been set yet', () => {
+        const humanity = new HumanityCheck();
+
+        expect(humanity.isBot()).to.equal(true);
+      });
+
+      it('Should return false if it does not detect the user is a bot user nor webdriver and the session variable is set', () => {
         const humanity = new HumanityCheck();
 
         expect(humanity.isBot()).to.equal(true);
         store.session.set(storageKey, true);
         expect(humanity.isBot()).to.equal(false);
-        expect(store.session.get(storageKey)).to.equal(true);
       });
     });
   }

--- a/spec/src/utils/humanity-check.js
+++ b/spec/src/utils/humanity-check.js
@@ -17,7 +17,7 @@ const bundled = process.env.BUNDLED === 'true';
 describe('ConstructorIO - Utils - Humanity Check', () => {
   // Don't run tests in bundle context, as these tests are for library internals
   if (!bundled) {
-    describe('isHuman', () => {
+    describe('constructor', () => {
       const storageKey = '_constructorio_is_human';
       let cleanup;
 
@@ -37,28 +37,20 @@ describe('ConstructorIO - Utils - Humanity Check', () => {
       it('Should not have isHuman flag set on initial instantiation', () => {
         const humanity = new HumanityCheck();
 
-        expect(humanity.isHuman()).to.equal(false);
+        expect(humanity.hasPerformedHumanEvent).to.equal(false);
         expect(store.session.get(storageKey)).to.equal(null);
       });
 
       it('Should have isHuman flag set if human-like actions are detected', () => {
         const humanity = new HumanityCheck();
 
-        expect(humanity.isHuman()).to.equal(false);
+        expect(humanity.hasPerformedHumanEvent).to.equal(false);
         helpers.triggerResize();
-        expect(humanity.isHuman()).to.equal(true);
-        expect(store.session.get(storageKey)).to.equal(true);
-      });
-
-      it('Should have isHuman flag set if session variable is set', () => {
-        const humanity = new HumanityCheck();
-
-        expect(humanity.isHuman()).to.equal(false);
-        store.session.set(storageKey, true);
-        expect(humanity.isHuman()).to.equal(true);
+        expect(humanity.hasPerformedHumanEvent).to.equal(true);
         expect(store.session.get(storageKey)).to.equal(true);
       });
     });
+
     describe('isBot', () => {
       const storageKey = '_constructorio_is_human';
       let cleanup;
@@ -88,12 +80,12 @@ describe('ConstructorIO - Utils - Humanity Check', () => {
         expect(store.session.get(storageKey)).to.equal(null);
       });
 
-      it('Should return true if it detects a webdriver and the session variable is set', () => {
+      it('Should return true if it detects a webdriver and the session variable is set via human-like action', () => {
         window.navigator.webdriver = true;
         const humanity = new HumanityCheck();
 
         expect(humanity.isBot()).to.equal(true);
-        store.session.set(storageKey, true);
+        helpers.triggerResize();
         expect(humanity.isBot()).to.equal(true);
         expect(store.session.get(storageKey)).to.equal(true);
       });
@@ -106,12 +98,12 @@ describe('ConstructorIO - Utils - Humanity Check', () => {
         expect(store.session.get(storageKey)).to.equal(null);
       });
 
-      it('Should return true if it detects a bot user agent and the session variable is set', () => {
+      it('Should return true if it detects a bot user agent and the session variable is set via human-like action', () => {
         window.navigator.__defineGetter__('userAgent', () => 'Mozilla/5.0 (Linux; Android 5.0) AppleWebKit/537.36 (KHTML, like Gecko) Mobile Safari/537.36 (compatible; Bytespider; spider-feedback@bytedance.com)');
         const humanity = new HumanityCheck();
 
         expect(humanity.isBot()).to.equal(true);
-        store.session.set(storageKey, true);
+        helpers.triggerResize();
         expect(humanity.isBot()).to.equal(true);
         expect(store.session.get(storageKey)).to.equal(true);
       });
@@ -122,11 +114,11 @@ describe('ConstructorIO - Utils - Humanity Check', () => {
         expect(humanity.isBot()).to.equal(true);
       });
 
-      it('Should return false if it does not detect the user is a bot user nor webdriver and the session variable is set', () => {
+      it('Should return false if it does not detect the user is a bot/webdriver and the session variable is set via human-like action', () => {
         const humanity = new HumanityCheck();
 
         expect(humanity.isBot()).to.equal(true);
-        store.session.set(storageKey, true);
+        helpers.triggerResize();
         expect(humanity.isBot()).to.equal(false);
       });
     });

--- a/spec/src/utils/humanity-check.js
+++ b/spec/src/utils/humanity-check.js
@@ -1,6 +1,8 @@
-/* eslint-disable no-underscore-dangle */
-/* eslint-disable no-restricted-properties */
-/* eslint-disable import/no-unresolved */
+/* eslint-disable
+  no-underscore-dangle,
+  no-restricted-properties,
+  import/no-unresolved
+*/
 const dotenv = require('dotenv');
 const chai = require('chai');
 const chaiAsPromised = require('chai-as-promised');

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -346,15 +346,15 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
 
       describe('Single Instance', () => {
         it('Should send all url tracking requests if queue is populated and user is human', (done) => {
-          store.session.set(humanityStorageKey, true);
           const requests = new RequestQueue(requestQueueOptions);
+
+          helpers.triggerResize(); // Human-like action
 
           requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
           requests.queue('https://ac.cnstrc.com/behavior?action=focus');
           requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
 
           expect(RequestQueue.get()).to.be.an('array').length(3);
-          helpers.triggerResize();
           requests.send();
 
           setTimeout(() => {
@@ -386,17 +386,22 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         it('Should not send tracking requests if queue was populated and user is not human', (done) => {
           const requests = new RequestQueue(requestQueueOptions);
 
-          // Set humanity session variable in order to queue some events
-          store.session.set(humanityStorageKey, true);
-
-          requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
-          requests.queue('https://ac.cnstrc.com/behavior?action=focus');
-          requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+          store.local.set(storageKey, [
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=session_start',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=focus',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+              method: 'GET',
+            },
+          ]);
 
           expect(RequestQueue.get()).to.be.an('array').length(3);
-
-          // Remove humanity session variable to emulate a bot trying to send requests
-          store.session.set(humanityStorageKey, false);
 
           requests.send();
 
@@ -409,12 +414,20 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         it('Should not send tracking requests if queue is populated and user is human and page is unloading', (done) => {
           const requests = new RequestQueue(requestQueueOptions);
 
-          // Set humanity session variable in order to queue some events
-          store.session.set(humanityStorageKey, true);
-
-          requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
-          requests.queue('https://ac.cnstrc.com/behavior?action=focus');
-          requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+          store.local.set(storageKey, [
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=session_start',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=focus',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+              method: 'GET',
+            },
+          ]);
 
           expect(RequestQueue.get()).to.be.an('array').length(3);
           helpers.triggerResize();
@@ -430,12 +443,20 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
         it('Should not send tracking requests if queue is populated and user is human and page is unloading and send was called before unload', (done) => {
           const requests = new RequestQueue(requestQueueOptions);
 
-          // Set humanity session variable in order to queue some events
-          store.session.set(humanityStorageKey, true);
-
-          requests.queue('https://ac.cnstrc.com/behavior?action=session_start');
-          requests.queue('https://ac.cnstrc.com/behavior?action=focus');
-          requests.queue('https://ac.cnstrc.com/behavior?action=magic_number_three');
+          store.local.set(storageKey, [
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=session_start',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=focus',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+              method: 'GET',
+            },
+          ]);
 
           expect(RequestQueue.get()).to.be.an('array').length(3);
           helpers.triggerResize();
@@ -748,14 +769,28 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
           const sendSpy1 = sinon.spy(requests1, 'send');
           const sendSpy2 = sinon.spy(requests2, 'send');
 
-          // Set humanity session variable in order to queue some events
-          store.session.set(humanityStorageKey, true);
-
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_one' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_two' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_three' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_four' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_five' });
+          store.local.set(storageKey, [
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=session_start',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=focus',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_four',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_five',
+              method: 'GET',
+            },
+          ]);
 
           helpers.triggerResize();
           requests1.send();
@@ -777,14 +812,28 @@ describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
           const sendSpy1 = sinon.spy(requests1, 'send');
           const sendSpy2 = sinon.spy(requests2, 'send');
 
-          // Set humanity session variable in order to queue some events
-          store.session.set(humanityStorageKey, true);
-
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_one' });
-          requests2.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_two' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_three' });
-          requests2.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_four' });
-          requests1.queue('https://ac.cnstrc.com/behavior', 'POST', { action: 'number_five' });
+          store.local.set(storageKey, [
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=session_start',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=focus',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_three',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_four',
+              method: 'GET',
+            },
+            {
+              url: 'https://ac.cnstrc.com/behavior?action=magic_number_five',
+              method: 'GET',
+            },
+          ]);
 
           helpers.triggerResize();
           requests1.send();

--- a/spec/src/utils/request-queue.js
+++ b/spec/src/utils/request-queue.js
@@ -25,7 +25,7 @@ dotenv.config();
 const bundled = process.env.BUNDLED === 'true';
 const testApiKey = process.env.TEST_REQUEST_API_KEY;
 
-describe('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
+describe.only('ConstructorIO - Utils - Request Queue', function utilsRequestQueue() {
   // Don't run tests in bundle context, as these tests are for library internals
   if (!bundled) {
     this.timeout(3000);

--- a/src/utils/humanity-check.js
+++ b/src/utils/humanity-check.js
@@ -49,14 +49,14 @@ class HumanityCheck {
 
   // Return boolean indicating if useragent matches botlist
   isBot() {
-    if (this.getIsHumanFromSessionStorage()) {
-      return false;
-    }
-
     const { userAgent, webdriver } = helpers.getNavigator();
     const botRegex = new RegExp(`(${botList.join('|')})`);
+    const isBot = Boolean(userAgent.match(botRegex)) || Boolean(webdriver);
 
-    return Boolean(userAgent.match(botRegex)) || Boolean(webdriver);
+    // Always check the user agent and webdriver fields first to determine if the user is a bot
+    // ... If it isn't, we'll follow up the check by looking at the storage variable to make sure
+    // ... the user passes the human check
+    return isBot || !this.getIsHumanFromSessionStorage();
   }
 }
 

--- a/src/utils/humanity-check.js
+++ b/src/utils/humanity-check.js
@@ -18,11 +18,12 @@ const humanEvents = [
 
 class HumanityCheck {
   constructor() {
-    this.isHumanBoolean = this.getIsHumanFromSessionStorage();
+    // Check if a human event has been performed in the past
+    this.hasPerformedHumanEvent = !!store.session.get(storageKey) || false;
 
-    // Humanity proved, remove handlers to prove humanity
+    // Humanity proved, remove handlers
     const remove = () => {
-      this.isHumanBoolean = true;
+      this.hasPerformedHumanEvent = true;
 
       store.session.set(storageKey, true);
       humanEvents.forEach((eventType) => {
@@ -31,32 +32,33 @@ class HumanityCheck {
     };
 
     // Add handlers to prove humanity
-    if (!this.isHumanBoolean) {
+    if (!this.hasPerformedHumanEvent) {
       humanEvents.forEach((eventType) => {
         helpers.addEventListener(eventType, remove, true);
       });
     }
   }
 
-  getIsHumanFromSessionStorage() {
-    return !!store.session.get(storageKey) || false;
-  }
-
-  // Return boolean indicating if is human
-  isHuman() {
-    return this.isHumanBoolean || !!store.session.get(storageKey);
-  }
-
-  // Return boolean indicating if useragent matches botlist
+  // Return boolean indicating if user is a bot
+  // ...if it has a bot-like useragent
+  // ...or uses webdriver
+  // ...or has not performed a human event
   isBot() {
     const { userAgent, webdriver } = helpers.getNavigator();
     const botRegex = new RegExp(`(${botList.join('|')})`);
-    const isBot = Boolean(userAgent.match(botRegex)) || Boolean(webdriver);
 
     // Always check the user agent and webdriver fields first to determine if the user is a bot
-    // ... If it isn't, we'll follow up the check by looking at the storage variable to make sure
-    // ... the user passes the human check
-    return isBot || !this.getIsHumanFromSessionStorage();
+    if (Boolean(userAgent.match(botRegex)) || Boolean(webdriver)) {
+      return true;
+    }
+
+    // If the user hasn't performed a human event, it indicates it is a bot
+    if (!this.hasPerformedHumanEvent) {
+      return true;
+    }
+
+    // Otherwise, it is a human
+    return false;
   }
 }
 

--- a/src/utils/request-queue.js
+++ b/src/utils/request-queue.js
@@ -54,7 +54,7 @@ class RequestQueue {
 
     if (
       // Consider user "human" if no DOM context is available
-      (!helpers.canUseDOM() || this.humanity.isHuman())
+      (!helpers.canUseDOM() || !this.humanity.isBot())
       && !this.requestPending
       && !this.pageUnloading
       && queue.length


### PR DESCRIPTION
### Updates:
* Update bot check logic to always check user agent. This in turn will ensure that no events from bot-like "users" get put in the request queue
* Add/update tests

### Notes:

This PR was aiming to keep things mostly the same without changing too many things. There are a couple different ways we could go about updating the existing logic and here are a few (feel free to comment if you have other thoughts/ideas as well):

**Current Solution:**
The current state works well for the most part, but fails if the crawler/scraper is able to perform some "human-like" action due to the current logic we have in place. Once humanity is determined, it will always rely on the isHuman variable that's saved to storage and doesn't do any more checks. This makes it easy for crawlers/scrapers to bypass any additional checks.

**Proposed Solution 1 (This PR):**
Not a whole lot changed except for checking the User Agent every time before a request is queued in addition to making sure that the user has proven that they're human.

**Proposed Solution 2:**
Check the User Agent when the client is instantiated and set `sendTrackingEvents` to false if it's a bot-like User Agent. This would disable tracking events entirely and no events can be queued.

**Proposed Solution 3:**
The isHuman (`__cnstrc_is_human`) variable is currently set after a human-like action has been performed on the page (i.e. scroll, click, mouseover, etc). We could add another condition where we check the User Agent before the isHuman variable ets set, so even if the “user” performs a human-like action, they would be required to have a non-bot-like user agent for events to get queued.