### PR TITLE
Fix the type of eventDispatcher in ConstructorClientOptions

### DIFF
--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -37,6 +37,11 @@ export interface IdOptions extends Record<string, any> {
   session_id_storage_location?: string;
 }
 
+export interface EventDispatcherOptions {
+  enabled?: boolean;
+  waitForBeacon?: boolean;
+}
+
 export interface ConstructorClientOptions {
   apiKey: string;
   version?: string;
@@ -53,7 +58,7 @@ export interface ConstructorClientOptions {
   trackingSendDelay?: number;
   sendTrackingEvents?: boolean;
   sendReferrerWithTrackingEvents?: boolean;
-  eventDispatcher?: EventDispatcher;
+  eventDispatcher?: EventDispatcherOptions;
   beaconMode?: boolean;
   networkParameters?: NetworkParameters;
 }


### PR DESCRIPTION
**Before:**

- `eventDispatcher` referenced the class `EventDispatcher` type instead of the `eventDispatcher` configuration options


**After:**
- `eventDispatcher` references `EventDispatcherOptions` which is `eventDispatcher` configuration options