### PR TITLE
Add UTM parameters to origin_referrer

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -34,7 +34,7 @@ function validateOriginReferrer(requestParams) {
   expect(requestParams).to.have.property('origin_referrer').to.contain('utm_campaign=campaign_1');
 }
 
-describe.only(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
+describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
   let fetchSpy = null;
   let cleanup;
   const jsdomOptions = { url };

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -2121,7 +2121,6 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         // Body
         expect(bodyParams).to.have.property('result_count').to.equal(requiredParameters.numResults);
         expect(bodyParams).to.have.property('url').to.equal(window?.location?.href);
-        expect(bodyParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
         expect(bodyParams).to.have.property('search_term').to.equal(term);
         expect(bodyParams).to.have.property('url').to.equal(window?.location?.href);
         expect(bodyParams).to.have.property('key');
@@ -2129,6 +2128,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(bodyParams).to.have.property('s');
         expect(bodyParams).to.have.property('c').to.equal(clientVersion);
         expect(bodyParams).to.have.property('_dt');
+        validateOriginReferrer(bodyParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -2369,7 +2369,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         validateOriginReferrer(requestParams);
 
         // Body
-        expect(bodyParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(bodyParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -29,7 +29,7 @@ const url = `http://localhost.test/path/name?query=term&category=cat&${utmParame
 const originReferrer = `localhost.test/path/name?${utmParameters}`;
 
 function validateOriginReferrer(requestParams) {
-  expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+  expect(requestParams).to.have.property('origin_referrer').to.contain('localhost.test/path/name');
   expect(requestParams).to.have.property('origin_referrer').to.contain('utm_source=attentive');
   expect(requestParams).to.have.property('origin_referrer').to.contain('utm_medium=sms');
   expect(requestParams).to.have.property('origin_referrer').to.contain('utm_campaign=campaign_1');

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -24,11 +24,21 @@ const skipNetworkTimeoutTests = process.env.SKIP_NETWORK_TIMEOUT_TESTS === 'true
 const bundledDescriptionSuffix = bundled ? ' - Bundled' : '';
 const timeoutRejectionMessage = 'AbortError: This operation was aborted';
 const testAnalyticsTag = { param1: 'test', param2: 'test2' };
+const utmParameters = 'utm_source=attentive&utm_medium=sms&utm_campaign=campaign_1';
+const url = `http://localhost.test/path/name?query=term&category=cat&${utmParameters}`;
+const originReferrer = `localhost.test/path/name?${utmParameters}`;
+
+function validateOriginReferrer(requestParams) {
+  expect(requestParams).to.have.property('origin_referrer').to.equal(originReferrer);
+  expect(requestParams).to.have.property('origin_referrer').to.contain('utm_source=attentive');
+  expect(requestParams).to.have.property('origin_referrer').to.contain('utm_medium=sms');
+  expect(requestParams).to.have.property('origin_referrer').to.contain('utm_campaign=campaign_1');
+}
 
 describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
   let fetchSpy = null;
   let cleanup;
-  const jsdomOptions = { url: 'http://localhost.test/path/name?query=term&category=cat' };
+  const jsdomOptions = { url };
   const requestQueueOptions = {
     sendTrackingEvents: true,
     trackingSendDelay: 1,
@@ -80,7 +90,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -110,7 +120,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('action').to.equal('session_start');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -186,7 +196,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -211,7 +221,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -418,7 +428,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('user_input').to.equal(userInput);
@@ -456,7 +466,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('action').to.equal('focus');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -533,7 +543,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -722,7 +732,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('user_input').to.equal(requiredParameters.originalQuery);
@@ -778,7 +788,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('user_input').to.equal(snakeCaseParameters.original_query);
@@ -829,7 +839,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('original_query').to.equal(snakeCaseParameters.original_query);
         expect(requestParams).to.have.property('item_id').to.equal(snakeCaseParameters.item_id);
         expect(requestParams).to.have.property('section').to.equal(snakeCaseParameters.section);
@@ -867,7 +877,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.originalQuery);
         expect(requestParams).to.have.property('section').to.equal(requiredParameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1026,7 +1036,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1215,7 +1225,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('item_id').to.equal(snakeCaseParameters.item_id);
         expect(requestParams).to.have.property('item_name').to.equal(snakeCaseParameters.item_name);
         expect(requestParams).to.have.property('variation_id').to.equal(snakeCaseParameters.variation_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -1246,7 +1256,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.itemId);
         expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -1387,7 +1397,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -1489,7 +1499,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('user_input').to.equal(snakeCaseParameters.original_query);
@@ -1528,7 +1538,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('user_input').to.equal(requiredParameters.originalQuery);
@@ -1572,7 +1582,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(snakeCaseParameters.original_query);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1602,7 +1612,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('original_query').to.equal(requiredParameters.originalQuery);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -1756,7 +1766,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -2013,7 +2023,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('result_count').to.equal(snakeCaseParameters.num_results);
@@ -2059,7 +2069,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('result_count').to.equal(requiredParameters.numResults);
@@ -2106,7 +2116,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('result_count').to.equal(requiredParameters.numResults);
@@ -2356,7 +2366,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
@@ -2618,7 +2628,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('item_name').to.equal(snakeCaseParameters.item_name);
@@ -2662,7 +2672,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Body
         expect(bodyParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
@@ -2718,7 +2728,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('name').to.equal(snakeCaseParameters.item_name);
         expect(requestParams).to.have.property('customer_id').to.equal(snakeCaseParameters.item_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -2749,7 +2759,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('name').to.equal(requiredParameters.itemName);
         expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.itemId);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -2941,7 +2951,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('name').to.equal(requiredParameters.itemName);
         expect(requestParams).to.have.property('customer_id').to.equal(requiredParameters.itemId);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('item_is_convertible').to.equal('false');
 
         // Response
@@ -2994,7 +3004,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('GET');
@@ -3204,7 +3214,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(snakeCaseParameters.item_id);
         expect(requestParams).to.have.property('revenue').to.equal(snakeCaseParameters.revenue.toString());
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3235,7 +3245,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.itemId);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue.toString());
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3271,7 +3281,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('item_name').to.equal(optionalParameters.itemName);
         expect(requestParams).to.have.property('variation_id').to.equal(optionalParameters.variationId);
         expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3594,7 +3604,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('item_name').to.equal(parameters.name);
         expect(requestParams).to.have.property('revenue').to.equal(parameters.revenue.toString());
         expect(requestParams).to.have.property('section').to.equal(parameters.section);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3650,7 +3660,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -3828,7 +3838,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('items').to.deep.equal(snakeCaseParameters.items);
         expect(requestParams).to.have.property('revenue').to.equal(snakeCaseParameters.revenue);
 
@@ -3859,7 +3869,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('items').to.deep.equal(snakeCaseItems);
         expect(requestParams).to.have.property('revenue').to.equal(requiredParameters.revenue);
 
@@ -4054,7 +4064,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4294,7 +4304,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('url').to.equal(snakeCaseParameters.url);
         expect(requestParams).to.have.property('pod_id').to.equal(snakeCaseParameters.pod_id);
         expect(requestParams).to.have.property('num_results_viewed').to.equal(snakeCaseParameters.num_results_viewed);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4326,7 +4336,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
         expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.podId);
         expect(requestParams).to.have.property('num_results_viewed').to.equal(requiredParameters.numResultsViewed);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4527,7 +4537,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4701,7 +4711,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('pod_id').to.equal(snakeCaseParameters.pod_id);
         expect(requestParams).to.have.property('strategy_id').to.equal(snakeCaseParameters.strategy_id);
         expect(requestParams).to.have.property('item_id').to.equal(snakeCaseParameters.item_id);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4733,7 +4743,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('pod_id').to.equal(requiredParameters.podId);
         expect(requestParams).to.have.property('strategy_id').to.equal(requiredParameters.strategyId);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.itemId);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4770,7 +4780,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('pod_id').to.equal(parametersWithItemName.pod_id);
         expect(requestParams).to.have.property('strategy_id').to.equal(parametersWithItemName.strategy_id);
         expect(requestParams).to.have.property('item_name').to.equal(parametersWithItemName.item_name);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4807,7 +4817,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('pod_id').to.equal(parametersWithItemName.podId);
         expect(requestParams).to.have.property('strategy_id').to.equal(parametersWithItemName.strategyId);
         expect(requestParams).to.have.property('item_name').to.equal(parametersWithItemName.itemName);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -4979,7 +4989,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5178,7 +5188,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('filter_name').to.equal(snakeCaseParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(snakeCaseParameters.filter_value);
         expect(requestParams).to.have.property('url').to.equal(snakeCaseParameters.url);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5212,7 +5222,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filterName);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filterValue);
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5384,7 +5394,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5578,7 +5588,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filterName);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filterValue);
         expect(requestParams).to.have.property('search_term').to.equal(requiredParameters.searchTerm);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5748,7 +5758,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5935,7 +5945,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('item_name').to.equal(snakeCaseParameters.item_name);
         expect(requestParams).to.have.property('filter_name').to.equal(snakeCaseParameters.filter_name);
         expect(requestParams).to.have.property('filter_value').to.equal(snakeCaseParameters.filter_value);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -5968,7 +5978,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
         expect(requestParams).to.have.property('filter_name').to.equal(requiredParameters.filterName);
         expect(requestParams).to.have.property('filter_value').to.equal(requiredParameters.filterValue);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -6178,7 +6188,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -6362,7 +6372,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('item_id').to.equal(snakeCaseParameters.item_id);
 
         // Response
@@ -6392,7 +6402,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('item_id').to.equal(requiredParameters.itemId);
 
         // Response
@@ -6595,7 +6605,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -6779,7 +6789,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(snakeCaseParameters.quiz_id);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(snakeCaseParameters.quiz_version_id);
         expect(requestParams).to.have.property('url').to.equal(snakeCaseParameters.url);
@@ -6811,7 +6821,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(requiredParameters.quizId);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(requiredParameters.quizVersionId);
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
@@ -6845,7 +6855,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(requiredParameters.quizId);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(requiredParameters.quizVersionId);
         expect(requestParams).to.have.property('url').to.equal(requiredParameters.url);
@@ -7065,7 +7075,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -7233,7 +7243,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(snakeCaseParameters.quiz_id);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(snakeCaseParameters.quiz_version_id);
         expect(requestParams).to.have.property('item_name').to.equal(snakeCaseParameters.item_name);
@@ -7266,7 +7276,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(requiredParameters.quizId);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(requiredParameters.quizVersionId);
         expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
@@ -7505,7 +7515,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -7672,7 +7682,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(snakeCaseParameters.quiz_id);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(snakeCaseParameters.quiz_version_id);
         expect(requestParams).to.have.property('item_name').to.equal(snakeCaseParameters.item_name);
@@ -7705,7 +7715,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('quiz_id').to.equal(requiredParameters.quizId);
         expect(requestParams).to.have.property('quiz_version_id').to.equal(requiredParameters.quizVersionId);
         expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
@@ -7944,7 +7954,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8173,7 +8183,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8312,7 +8322,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8463,7 +8473,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8604,7 +8614,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8756,7 +8766,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('_dt');
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
         expect(requestParams).to.have.property('search_result_count').to.equal(requiredParameters.searchResultCount);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -8897,7 +8907,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -9053,7 +9063,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('s');
         expect(requestParams).to.have.property('c').to.equal(clientVersion);
         expect(requestParams).to.have.property('_dt');
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
         expect(requestParams).to.have.property('search_result_id').to.equal(requiredParameters.searchResultId);
         expect(requestParams).to.have.property('item_name').to.equal(requiredParameters.itemName);
@@ -9199,7 +9209,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -9376,7 +9386,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
         expect(requestParams).to.have.property('search_result_id').to.equal(requiredParameters.searchResultId);
         expect(requestParams).to.have.property('num_results_viewed').to.equal(requiredParameters.numResultsViewed);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -9517,7 +9527,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -9670,7 +9680,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('intent').to.equal(requiredParameters.intent);
         expect(requestParams).to.have.property('search_term').to.equal(requiredParameters.searchTerm);
         expect(requestParams).to.have.property('search_result_id').to.equal(requiredParameters.searchResultId);
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -9810,7 +9820,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
 
         // Request
         expect(fetchSpy).to.have.been.called;
-        expect(requestParams).to.have.property('origin_referrer').to.equal('localhost.test/path/name');
+        validateOriginReferrer(requestParams);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');

--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -26,7 +26,6 @@ const timeoutRejectionMessage = 'AbortError: This operation was aborted';
 const testAnalyticsTag = { param1: 'test', param2: 'test2' };
 const utmParameters = 'utm_source=attentive&utm_medium=sms&utm_campaign=campaign_1';
 const url = `http://localhost.test/path/name?query=term&category=cat&${utmParameters}`;
-const originReferrer = `localhost.test/path/name?${utmParameters}`;
 
 function validateOriginReferrer(requestParams) {
   expect(requestParams).to.have.property('origin_referrer').to.contain('localhost.test/path/name');
@@ -35,7 +34,7 @@ function validateOriginReferrer(requestParams) {
   expect(requestParams).to.have.property('origin_referrer').to.contain('utm_campaign=campaign_1');
 }
 
-describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
+describe.only(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
   let fetchSpy = null;
   let cleanup;
   const jsdomOptions = { url };

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -67,15 +67,12 @@ function applyParams(parameters, options) {
 
     if (search) {
       try {
-        const utmParamKeys = ['utm_source', 'utm_medium', 'utm_campaign'];
         const utmQueryParamStrArr = [];
         const searchParams = new URLSearchParams(search);
 
-        utmParamKeys.forEach((key) => {
-          const utmParamValue = searchParams.get(key);
-
-          if (utmParamValue) {
-            utmQueryParamStrArr.push(`${key}=${utmParamValue}`);
+        searchParams.forEach((value, key) => {
+          if (key.match(/utm_/)) {
+            utmQueryParamStrArr.push(`${key}=${value}`);
           }
         });
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-depth */
 /* eslint-disable complexity */
 /* eslint-disable max-len */
 /* eslint-disable object-curly-newline, no-underscore-dangle, camelcase, no-unneeded-ternary */
@@ -17,7 +18,7 @@ function applyParams(parameters, options) {
     requestMethod,
     beaconMode,
   } = options;
-  const { host, pathname } = helpers.getWindowLocation();
+  const { host, pathname, search } = helpers.getWindowLocation();
   const sendReferrerWithTrackingEvents = (options.sendReferrerWithTrackingEvents === false)
     ? false
     : true; // Defaults to 'true'
@@ -62,6 +63,37 @@ function applyParams(parameters, options) {
 
     if (pathname) {
       aggregateParams.origin_referrer += pathname;
+    }
+
+    if (search) {
+      try {
+        const searchParams = new URLSearchParams(search);
+        const utmSource = searchParams.get('utm_source');
+        const utmMedium = searchParams.get('utm_medium');
+        const utmCampaign = searchParams.get('utm_campaign');
+
+        // Add UTM parameters to origin_referrer if they exist
+        if (utmSource || utmMedium || utmCampaign) {
+          aggregateParams.origin_referrer += '?';
+
+          if (utmSource) {
+            aggregateParams.origin_referrer += `utm_source=${utmSource}`;
+          }
+
+          if (utmMedium) {
+            if (utmSource) aggregateParams.origin_referrer += '&';
+            aggregateParams.origin_referrer += `utm_medium=${utmMedium}`;
+          }
+
+          if (utmCampaign) {
+            if (utmSource || utmMedium) aggregateParams.origin_referrer += '&';
+            aggregateParams.origin_referrer += `utm_campaign=${utmCampaign}`;
+          }
+        }
+      } catch (e) {
+        // If there's an error parsing the URL parameters, continue without them
+        console.warn('Error extracting UTM parameters:', e);
+      }
     }
   }
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -67,28 +67,20 @@ function applyParams(parameters, options) {
 
     if (search) {
       try {
+        const utmParamKeys = ['utm_source', 'utm_medium', 'utm_campaign'];
+        const utmQueryParamStrArr = [];
         const searchParams = new URLSearchParams(search);
-        const utmSource = searchParams.get('utm_source');
-        const utmMedium = searchParams.get('utm_medium');
-        const utmCampaign = searchParams.get('utm_campaign');
 
-        // Add UTM parameters to origin_referrer if they exist
-        if (utmSource || utmMedium || utmCampaign) {
-          aggregateParams.origin_referrer += '?';
+        utmParamKeys.forEach((key) => {
+          const utmParamValue = searchParams.get(key);
 
-          if (utmSource) {
-            aggregateParams.origin_referrer += `utm_source=${utmSource}`;
+          if (utmParamValue) {
+            utmQueryParamStrArr.push(`${key}=${utmParamValue}`);
           }
+        });
 
-          if (utmMedium) {
-            if (utmSource) aggregateParams.origin_referrer += '&';
-            aggregateParams.origin_referrer += `utm_medium=${utmMedium}`;
-          }
-
-          if (utmCampaign) {
-            if (utmSource || utmMedium) aggregateParams.origin_referrer += '&';
-            aggregateParams.origin_referrer += `utm_campaign=${utmCampaign}`;
-          }
+        if (utmQueryParamStrArr.length) {
+          aggregateParams.origin_referrer += `?${utmQueryParamStrArr.join('&')}`;
         }
       } catch (e) {
         // Do nothing

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -91,8 +91,7 @@ function applyParams(parameters, options) {
           }
         }
       } catch (e) {
-        // If there's an error parsing the URL parameters, continue without them
-        console.warn('Error extracting UTM parameters:', e);
+        // Do nothing
       }
     }
   }


### PR DESCRIPTION
## Add Support for UTM parameters
### Where?
 Appended to the `origin_referrer` parameter in `tracker.js` module

### What are the supported  parameters
- utm_source
- utm_campain
- utm_medium

### Tests
- Added `validateOriginReferrer`
- Validates origin_referrer is appended with UTM parameters for all tracking events
