### PR TITLE
[NOCI] TrackConversion - Remove Result ID from Docs

### DIFF
--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1024,7 +1024,6 @@ class Tracker {
    *         itemName: 'Red T-Shirt',
    *         variationId: 'KMH879-7632',
    *         type: 'like',
-   *         resultId: '019927c2-f955-4020-8b8d-6b21b93cb5a2',
    *         section: 'Products',
    *     },
    * );


### PR DESCRIPTION
Removing result ID from the docs since it isn't used in the track conversion call