### PR TITLE
[NOCI] Remove Sort Options From Docs

### DIFF
--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -307,8 +307,6 @@ class Browse {
    * @param {number} [parameters.offset] - The number of results to skip from the beginning (Can't be used together with page)
    * @param {number} [parameters.resultsPerPage] - The number of results per page to return
    * @param {object} [parameters.filters] - Filters used to refine results
-   * @param {string} [parameters.sortBy='relevance'] - The sort method for results
-   * @param {string} [parameters.sortOrder='descending'] - The sort order for results
    * @param {string} [parameters.section='Products'] - The section name for results
    * @param {object} [parameters.fmtOptions] - The format options used to refine result groups. Please refer to https://docs.constructor.com/reference/browse-browse-results for details
    * @param {string[]} [parameters.hiddenFields] - Hidden metadata fields to return


### PR DESCRIPTION
Remove sort options from the browse by item id endpoint docs because it is not a supported parameter

https://docs.constructor.com/reference/v1-browse-get-browse-items-results

> The browse item endpoint accepts a list of items and returns a standard browse response structure. Additional filters may be passed in the request, but custom sort orders are not supported (items will always be returned in the order of ids that are specified in the request).