### PR TITLE
[CDX-210] Add support for seedItemIds in trackRecommendationClick

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -5376,34 +5376,96 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       expect(tracker.trackRecommendationClick(parametersWithSeedItemIds)).to.equal(true);
     });
 
-    it('Should throw an error when invalid seedItemIds format is provided (number)', () => {
-      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
-      const parametersWithInvalidSeedItemIds = {
+    it('Should respond with a valid response and convert seedItemIds to array when provided as string', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const parametersWithSeedItemIds = {
+        ...requiredParameters,
+        seedItemIds: 'item-123',
+      };
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('seed_item_ids').to.deep.equal(['item-123']);
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+        done();
+      });
+      expect(tracker.trackRecommendationClick(parametersWithSeedItemIds)).to.equal(true);
+    });
+
+    it('Should respond with a valid response and convert seedItemIds to array when provided as number', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const parametersWithSeedItemIds = {
         ...requiredParameters,
         seedItemIds: 123,
       };
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds)).to.be.an('error');
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds).message).to.equal('seedItemIds must be an array of strings');
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.have.property('seed_item_ids').to.deep.equal(['123']);
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+        done();
+      });
+      expect(tracker.trackRecommendationClick(parametersWithSeedItemIds)).to.equal(true);
     });
 
-    it('Should throw an error when invalid seedItemIds format is provided (array with non-strings)', () => {
-      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
-      const parametersWithInvalidSeedItemIds = {
+    it('Should respond with a valid response and omit seed_item_ids when seedItemIds is empty string', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const parametersWithSeedItemIds = {
         ...requiredParameters,
-        seedItemIds: ['item-123', 456, 'item-789'],
+        seedItemIds: '',
       };
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds)).to.be.an('error');
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds).message).to.equal('seedItemIds must be an array of strings');
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('seed_item_ids');
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+        done();
+      });
+      expect(tracker.trackRecommendationClick(parametersWithSeedItemIds)).to.equal(true);
     });
 
-    it('Should throw an error when invalid seedItemIds format is provided (object)', () => {
-      const { tracker } = new ConstructorIO({ apiKey: testApiKey });
-      const parametersWithInvalidSeedItemIds = {
+    it('Should respond with a valid response and omit seed_item_ids when seedItemIds is empty array', (done) => {
+      const { tracker } = new ConstructorIO({
+        apiKey: testApiKey,
+        fetch: fetchSpy,
+        ...requestQueueOptions,
+      });
+      const parametersWithSeedItemIds = {
         ...requiredParameters,
-        seedItemIds: { id: 'item-123' },
+        seedItemIds: [],
       };
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds)).to.be.an('error');
-      expect(tracker.trackRecommendationClick(parametersWithInvalidSeedItemIds).message).to.equal('seedItemIds must be an array of strings');
+      tracker.on('success', (responseParams) => {
+        const requestParams = helpers.extractBodyParamsFromFetch(fetchSpy);
+        // Request
+        expect(fetchSpy).to.have.been.called;
+        expect(requestParams).to.not.have.property('seed_item_ids');
+        // Response
+        expect(responseParams).to.have.property('method').to.equal('POST');
+        expect(responseParams).to.have.property('message');
+        done();
+      });
+      expect(tracker.trackRecommendationClick(parametersWithSeedItemIds)).to.equal(true);
     });
   });
 

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1357,7 +1357,7 @@ class Tracker {
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
    * @param {string} [parameters.slCampaignId] - Pass campaign id of sponsored listing
    * @param {string} [parameters.slCampaignOwner] - Pass campaign owner of sponsored listing
-   * @param {string[]} [parameters.seedItemIds] - Item ID(s) of the seed item
+   * @param {string[]|string|number} [parameters.seedItemIds] - Item ID(s) to be used as seed
    * @returns {(true|Error)}
    * @description User clicked an item that appeared within a list of recommended results
    * @example
@@ -1466,14 +1466,12 @@ class Tracker {
         bodyParams.sl_campaign_owner = slCampaignOwner;
       }
 
-      if (seedItemIds) {
-        // Validate seedItemIds format
-        if (Array.isArray(seedItemIds) && seedItemIds.every((id) => typeof id === 'string')) {
-          bodyParams.seed_item_ids = seedItemIds;
-        } else {
-          this.requests.send();
-          return new Error('seedItemIds must be an array of strings');
-        }
+      if (typeof seedItemIds === 'number') {
+        bodyParams.seed_item_ids = [String(seedItemIds)];
+      } else if (seedItemIds?.length && typeof seedItemIds === 'string') {
+        bodyParams.seed_item_ids = [seedItemIds];
+      } else if (seedItemIds?.length && Array.isArray(seedItemIds)) {
+        bodyParams.seed_item_ids = seedItemIds;
       }
 
       const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;

--- a/src/types/tracker.d.ts
+++ b/src/types/tracker.d.ts
@@ -165,7 +165,7 @@ declare class Tracker {
       analyticsTags?: Record<string, string>;
       slCampaignId?: string;
       slCampaignOwner?: string;
-      seedItemIds?: string[];
+      seedItemIds?: string[] | string | number;
     },
     networkParameters?: NetworkParameters
   ): true | Error;


### PR DESCRIPTION
## Purpose

Adds optional `seedItemIds` parameter to strengthen recommendation tracking by providing seed item.

## Changes Made

### Implementation

- JavaScript (src/modules/tracker.js): Added parameter validation and snake_case conversion to seed_item_ids
- TypeScript (src/types/tracker.d.ts): Added seedItemIds?: string[] | string | number type definition for flexible input
- Tests (spec/src/modules/tracker.js): Validation and error handling tests

https://github.com/Constructor-io/constructorio-client-javascript/pull/375
