### PR TITLE
[REM-1993] Add sl tracking in recs result view

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -4335,6 +4335,8 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       resultId: 'result-id',
       section: 'Products',
       analyticsTags: testAnalyticsTag,
+      slCampaignId: '019927c2-f955-4020',
+      slCampaignOwner: 'constructor',
     };
 
     it('Backwards Compatibility - Should respond with a valid response when snake cased parameters are provided', (done) => {
@@ -4563,6 +4565,8 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('result_id').to.equal(optionalParameters.resultId);
         expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
         expect(requestParams).to.have.property('analytics_tags').to.deep.equal(testAnalyticsTag);
+        expect(requestParams).to.have.property('sl_campaign_id').to.deep.equal(optionalParameters.slCampaignId);
+        expect(requestParams).to.have.property('sl_campaign_owner').to.deep.equal(optionalParameters.slCampaignOwner);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -1232,6 +1232,8 @@ class Tracker {
    * @param {string[]|string|number} [parameters.seedItemIds] - Item ID(s) to be used as seed
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
+   * @param {string} [parameters.slCampaignId] - Pass campaign id of sponsored listing
+   * @param {string} [parameters.slCampaignOwner] - Pass campaign owner of sponsored listing
    * @returns {(true|Error)}
    * @description User viewed a set of recommendations
    * @example
@@ -1244,6 +1246,8 @@ class Tracker {
    *         url: 'https://demo.constructor.io/sandbox/farmstand',
    *         podId: '019927c2-f955-4020',
    *         numResultsViewed: 3,
+   *         slCampaignId: '019927c2-f955-4020',
+   *         slCampaignOwner: 'constructor',
    *     },
    * );
    */
@@ -1268,6 +1272,8 @@ class Tracker {
         analyticsTags,
         seedItemIds,
         resultCount = result_count || items?.length || 0,
+        slCampaignId,
+        slCampaignOwner,
       } = parameters;
 
       if (!helpers.isNil(resultCount)) {
@@ -1314,6 +1320,14 @@ class Tracker {
         bodyParams.seed_item_ids = [seedItemIds];
       } else if (seedItemIds?.length && Array.isArray(seedItemIds)) {
         bodyParams.seed_item_ids = seedItemIds;
+      }
+
+      if (slCampaignId) {
+        bodyParams.sl_campaign_id = slCampaignId;
+      }
+
+      if (slCampaignOwner) {
+        bodyParams.sl_campaign_owner = slCampaignOwner;
       }
 
       const requestURL = `${requestPath}${applyParamsAsString({}, this.options)}`;

--- a/src/types/tracker.d.ts
+++ b/src/types/tracker.d.ts
@@ -145,6 +145,8 @@ declare class Tracker {
       resultId?: string;
       section?: string;
       analyticsTags?: Record<string, string>;
+      slCampaignId?: string;
+      slCampaignOwner?: string;
     },
     networkParameters?: NetworkParameters
   ): true | Error;


### PR DESCRIPTION
Updates beacon to include sponsored listings tracking (campaign id, owner) for recommendations view events.

Continuation from https://github.com/Constructor-io/constructorio-client-javascript/pull/389 