### PR TITLE
Replace individual usernames with team in CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Define which teams own which parts of this repository
 
-* @jjl014 @esezen
+* @Constructor-io/integrations-dynamic-lib-javascript-admins


### PR DESCRIPTION
## Summary
- Replace individual GitHub usernames with `@Constructor-io/integrations-dynamic-lib-javascript-admins` team in CODEOWNERS

## Related
- [CDX-322](https://linear.app/constructor/issue/CDX-322/update-codeowners)