### PR TITLE
[AT-100]: Add optional description field to BaseQuestionOption interface

### DIFF
--- a/src/types/quizzes.d.ts
+++ b/src/types/quizzes.d.ts
@@ -170,6 +170,7 @@ export interface QuizResult extends Record<string, any> {
 
 export interface BaseQuestionOption extends Record<string, any> {
   value: string;
+  description?: Nullable<string>;
   attribute: Nullable<{
     name: string;
     value: string;

--- a/src/types/tests/quizzes.test-d.ts
+++ b/src/types/tests/quizzes.test-d.ts
@@ -19,6 +19,7 @@ expectAssignable<NextQuestionResponse>({
       {
         id: 1,
         value: 'Who',
+        description: 'A warm, vibrant red tone',
         attribute: {
           name: 'group_id',
           value: 'test-value',
@@ -27,6 +28,7 @@ expectAssignable<NextQuestionResponse>({
       {
         id: 2,
         value: 'What',
+        description: null,
         attribute: {
           name: 'group_id',
           value: 'test-value',


### PR DESCRIPTION
Add optional description field to BaseQuestionOption interface
https://linear.app/constructor/issue/AT-100/quiz-option-description-websitejs-libraryui-library