### PR TITLE
Better error logging on event failure

### DIFF
--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -143,7 +143,7 @@ EventEmitter.prototype.emit = function emit(type) {
       throw er; // Unhandled 'error' event
     }
     // At least give some kind of context to the user
-    var err = new Error('Unhandled error.' + (er && er.message ? ' (' + er.message + ')' : JSON.stringify(err)));
+    var err = new Error('Unhandled error.' + (er && er.message ? ' (' + er.message + ')' : JSON.stringify(er)));
     err.context = er;
     throw err; // Unhandled 'error' event
   }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -143,7 +143,7 @@ EventEmitter.prototype.emit = function emit(type) {
       throw er; // Unhandled 'error' event
     }
     // At least give some kind of context to the user
-    var err = new Error('Unhandled error.' + (er ? ' (' + er.message + ')' : ''));
+    var err = new Error('Unhandled error.' + (er && er.message ? ' (' + er.message + ')' : JSON.stringify(err)));
     err.context = er;
     throw err; // Unhandled 'error' event
   }

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -143,7 +143,22 @@ EventEmitter.prototype.emit = function emit(type) {
       throw er; // Unhandled 'error' event
     }
     // At least give some kind of context to the user
-    var err = new Error('Unhandled error.' + (er && er.message ? ' (' + er.message + ')' : JSON.stringify(er)));
+    var detail = '';
+    if (er && er.message) {
+      detail = ' (' + er.message + ')';
+    } else if (er !== undefined && er !== null) {
+      var serialized;
+      try {
+        serialized = JSON.stringify(er);
+      } catch (e) {
+        serialized = undefined;
+      }
+      if (typeof serialized !== 'string') {
+        serialized = Object.prototype.toString.call(er);
+      }
+      detail = ' (' + serialized + ')';
+    }
+    var err = new Error('Unhandled error.' + detail);
     err.context = er;
     throw err; // Unhandled 'error' event
   }


### PR DESCRIPTION
We're getting `Unhandled error. (undefined)`, which isn't super helpful. This PR retains the current logic (er.message is used when it exists), otherwise stringify the error and send it back as-is.