### PR TITLE
feat: Add option to allow http in serviceUrl, default false

### DIFF
--- a/spec/src/constructorio.js
+++ b/spec/src/constructorio.js
@@ -97,6 +97,22 @@ describe(`ConstructorIO${bundledDescriptionSuffix}`, () => {
     expect(instance.options).to.have.property('serviceUrl').to.equal('https://constructor.io');
   });
 
+  it('Should return an instance with correct serviceUrl when a http serviceUrl is passed and allowHttpServiceUrl is true', () => {
+    const clientId = 'client-id';
+    const sessionId = 'session-id';
+    const serviceUrl = 'http://constructor.io';
+    const instance = new ConstructorIO({
+      apiKey: validApiKey,
+      clientId,
+      sessionId,
+      serviceUrl,
+      allowHttpServiceUrl: true,
+    });
+
+    expect(instance).to.be.an('object');
+    expect(instance.options).to.have.property('serviceUrl').to.equal('http://constructor.io');
+  });
+
   it('Should remove any trailing slashes from the serviceUrl', () => {
     const serviceUrl = 'https://constructor.io/';
     const instance = new ConstructorIO({

--- a/spec/src/utils/helpers.js
+++ b/spec/src/utils/helpers.js
@@ -584,30 +584,71 @@ describe('ConstructorIO - Utils - Helpers', () => {
     });
 
     describe('addHTTPSToString', () => {
-      it('Should return the url without any modification', () => {
-        const testUrl = 'https://www.constructor.io';
+      describe('when allowHttp is not given', () => {
+        it('Should return the url without any modification', () => {
+          const testUrl = 'https://www.constructor.io';
 
-        expect(addHTTPSToString(testUrl)).to.equal(testUrl);
+          expect(addHTTPSToString(testUrl)).to.equal(testUrl);
+        });
+
+        it('Should return url with no protocol with https at the beginning', () => {
+          const testUrl = 'www.constructor.io';
+          const expectedUrl = 'https://www.constructor.io';
+
+          expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
+        });
+
+        it('Should return url with an http protocol with https at the beginning', () => {
+          const testUrl = 'http://www.constructor.io';
+          const expectedUrl = 'https://www.constructor.io';
+
+          expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
+        });
+
+        it('Should not replace "http" in the middle of the url', () => {
+          const testUrl = 'http://www.constructor.io/http/';
+          const expectedUrl = 'https://www.constructor.io/http/';
+
+          expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
+        });
+
+        it('Should return null if param is not a string', () => {
+          const testUrl = {};
+
+          expect(addHTTPSToString(testUrl)).to.equal(null);
+        });
       });
+      describe('when allowHttp is true', () => {
+        it('Should return the url without any modification', () => {
+          const testUrl = 'https://www.constructor.io';
 
-      it('Should return url with no protocol with https at the beginning', () => {
-        const testUrl = 'www.constructor.io';
-        const expectedUrl = 'https://www.constructor.io';
+          expect(addHTTPSToString(testUrl, true)).to.equal(testUrl);
+        });
 
-        expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
-      });
+        it('Should return url with no protocol with https at the beginning', () => {
+          const testUrl = 'www.constructor.io';
+          const expectedUrl = 'https://www.constructor.io';
 
-      it('Should return url with an http protocol with https at the beginning', () => {
-        const testUrl = 'http://www.constructor.io';
-        const expectedUrl = 'https://www.constructor.io';
+          expect(addHTTPSToString(testUrl, true)).to.equal(expectedUrl);
+        });
 
-        expect(addHTTPSToString(testUrl)).to.equal(expectedUrl);
-      });
+        it('Should return url with an http protocol without any modification', () => {
+          const testUrl = 'http://localhost:8080';
 
-      it('Should return null if param is not a string', () => {
-        const testUrl = {};
+          expect(addHTTPSToString(testUrl, true)).to.equal(testUrl);
+        });
 
-        expect(addHTTPSToString(testUrl)).to.equal(null);
+        it('Should not replace "http" in the middle of the url', () => {
+          const testUrl = 'http://www.constructor.io/http/';
+
+          expect(addHTTPSToString(testUrl, true)).to.equal(testUrl);
+        });
+
+        it('Should return null if param is not a string', () => {
+          const testUrl = {};
+
+          expect(addHTTPSToString(testUrl, true)).to.equal(null);
+        });
       });
     });
 

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -38,6 +38,7 @@ class ConstructorIO {
    * @param {object} parameters - Parameters for client instantiation
    * @param {string} parameters.apiKey - Constructor.io API key
    * @param {string} [parameters.serviceUrl='https://ac.cnstrc.com'] - API URL endpoint
+   * @param {boolean} [parameters.allowHttpServiceUrl=false] - Allow HTTP protocol in API URL endpoint
    * @param {string} [parameters.quizzesServiceUrl='https://quizzes.cnstrc.com'] - Quizzes API URL endpoint
    * @param {string} [parameters.agentServiceUrl='https://agent.cnstrc.com'] - AI Shopping Agent API URL endpoint
    * @param {string} [parameters.mediaServiceUrl='https://media-cnstrc.com'] - Media API URL endpoint
@@ -73,6 +74,7 @@ class ConstructorIO {
       apiKey,
       version: versionFromOptions,
       serviceUrl,
+      allowHttpServiceUrl,
       quizzesServiceUrl,
       agentServiceUrl,
       assistantServiceUrl,
@@ -121,7 +123,7 @@ class ConstructorIO {
     this.options = {
       apiKey,
       version: versionFromOptions || versionFromGlobal || computePackageVersion(),
-      serviceUrl: helpers.addHTTPSToString(normalizedServiceUrl) || 'https://ac.cnstrc.com',
+      serviceUrl: helpers.addHTTPSToString(normalizedServiceUrl, allowHttpServiceUrl) || 'https://ac.cnstrc.com',
       quizzesServiceUrl: (quizzesServiceUrl && quizzesServiceUrl.replace(/\/$/, '')) || 'https://quizzes.cnstrc.com',
       agentServiceUrl: (agentServiceUrl && agentServiceUrl.replace(/\/$/, '')) || 'https://agent.cnstrc.com',
       assistantServiceUrl: (assistantServiceUrl && assistantServiceUrl.replace(/\/$/, '')) || 'https://assistant.cnstrc.com',

--- a/src/constructorio.js
+++ b/src/constructorio.js
@@ -74,7 +74,7 @@ class ConstructorIO {
       apiKey,
       version: versionFromOptions,
       serviceUrl,
-      allowHttpServiceUrl,
+      allowHttpServiceUrl = false,
       quizzesServiceUrl,
       agentServiceUrl,
       assistantServiceUrl,

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -52,6 +52,7 @@ export interface ConstructorClientOptions {
   apiKey: string;
   version?: string;
   serviceUrl?: string;
+  allowHttpServiceUrl?: boolean;
   quizzesServiceUrl?: string;
   agentServiceUrl?: string;
   mediaServiceUrl?: string;

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -350,7 +350,7 @@ const utils = {
 
     return utils.throwHttpErrorFromResponse(new Error(), response);
   },
-  addHTTPSToString(url) {
+  addHTTPSToString(url, allowHttp = false) {
     if (typeof url !== 'string') {
       return null;
     }
@@ -359,6 +359,9 @@ const utils = {
     const doesUrlStartWithHTTP = url.startsWith('http://');
 
     if (!doesUrlIncludeHTTPS && doesUrlStartWithHTTP) {
+      if (allowHttp) {
+        return url;
+      }
       return url.replace('http', 'https');
     }
 


### PR DESCRIPTION
Would you approve adding an option to disable the "force https" feature from #309?

I have implemented a "fake Constructor" in our java backend so we can prototype changes to our catalog updates on our local machines without having to actually upload the catalog to a Constructor index. If not, we'll have keep using a fork of this repo, which would mean added maintenance work and delayed updates for the client library. Nevertheless it is net beneficial for us by letting us develop our Constructor experience in an agile manner.