### PR TITLE
Add .npmrc with security hardening settings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+save-exact=true

--- a/README.md
+++ b/README.md
@@ -52,8 +52,11 @@ window.addEventListener('cio.client.search.getSearchResults.completed', (event) 
 ## Development / npm commands
 
 ```bash
+npm run prepare       # one-time after cloning: install husky git hooks (pre-push lint)
 npm run lint          # run lint on source code and tests
 npm run test          # run tests
 npm run coverage      # run tests and serves coverage reports from localhost:8081
 npm run docs          # output documentation to `./docs` directory
 ```
+
+> **Note:** `.npmrc` sets `ignore-scripts=true` for supply-chain safety, so lifecycle scripts (including husky's hook installation) do not run automatically on `npm install`. Run `npm run prepare` once after cloning to enable the `pre-push` lint hook.


### PR DESCRIPTION
## Summary
- Adds `.npmrc` with `ignore-scripts=true` and `save-exact=true`
- `ignore-scripts=true` prevents arbitrary code execution during `npm install` (supply chain defense)
- `save-exact=true` pins exact dependency versions for reproducible builds

## If a package requires install scripts

Add a per-package allowlist in `.npmrc`:
```
lifecycle-script-allowed[]=sharp
lifecycle-script-allowed[]=esbuild
```

Or run one-off with:
```bash
npm install --ignore-scripts=false <package-name>
```

## Context
Part of an org-wide security hardening initiative for all npm-based repositories.