### PR TITLE
fix: don't mutate caller's fmtOptions when hiddenFields is passed

### DIFF
--- a/spec/src/modules/fmtOptions-immutability.js
+++ b/spec/src/modules/fmtOptions-immutability.js
@@ -7,24 +7,13 @@ const ConstructorIO = require('../../../test/constructorio'); // eslint-disable-
 // Regression guard for the `hidden_fields` side-effect: passing both
 // `fmtOptions` and `hiddenFields` must not mutate the caller's `fmtOptions`.
 describe('ConstructorIO - fmtOptions immutability', () => {
-  let fetchStub;
-
-  beforeEach(() => {
-    fetchStub = sinon.stub(global, 'fetch').resolves({
-      ok: true,
-      status: 200,
-      json: () => Promise.resolve({}),
-    });
-  });
-
-  afterEach(() => {
-    fetchStub.restore();
-  });
-
-  const client = () => new ConstructorIO({
+  // Inject the fetch stub through the client options, as the other module specs
+  // do (e.g. spec/src/modules/search.js), rather than stubbing the global.
+  const client = (fetch) => new ConstructorIO({
     apiKey: 'key_immutability_test',
     sessionId: 1,
     clientId: 'immutability-client-id',
+    fetch,
   });
 
   const cases = [
@@ -37,7 +26,12 @@ describe('ConstructorIO - fmtOptions immutability', () => {
 
   cases.forEach(([name, call]) => {
     it(`does not mutate the caller's fmtOptions object (${name})`, () => {
-      const c = client();
+      const fetchStub = sinon.stub().resolves({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
+      const c = client(fetchStub);
       const fmtOptions = { fields: ['id', 'name'] };
       const snapshot = JSON.parse(JSON.stringify(fmtOptions));
 

--- a/spec/src/modules/fmtOptions-immutability.js
+++ b/spec/src/modules/fmtOptions-immutability.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-unused-expressions, import/no-unresolved */
+const sinon = require('sinon');
+const ConstructorIO = require('../../../test/constructorio'); // eslint-disable-line import/extensions
+
+// Requests build their URL (and previously mutated `fmtOptions`) synchronously,
+// before `fetch` resolves, so a stubbed fetch is enough to exercise the bug.
+// Regression guard for the `hidden_fields` side-effect: passing both
+// `fmtOptions` and `hiddenFields` must not mutate the caller's `fmtOptions`.
+describe('ConstructorIO - fmtOptions immutability', () => {
+  let fetchStub;
+
+  beforeEach(() => {
+    fetchStub = sinon.stub(global, 'fetch').resolves({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({}),
+    });
+  });
+
+  afterEach(() => {
+    fetchStub.restore();
+  });
+
+  const client = () => new ConstructorIO({
+    apiKey: 'key_immutability_test',
+    sessionId: 1,
+    clientId: 'immutability-client-id',
+  });
+
+  const cases = [
+    ['autocomplete', (c, fmtOptions, hiddenFields) => c.autocomplete.getAutocompleteResults('shoes', { fmtOptions, hiddenFields })],
+    ['search', (c, fmtOptions, hiddenFields) => c.search.getSearchResults('shoes', { fmtOptions, hiddenFields })],
+    ['browse', (c, fmtOptions, hiddenFields) => c.browse.getBrowseResults('group_id', 'all', { fmtOptions, hiddenFields })],
+    ['recommendations', (c, fmtOptions, hiddenFields) => c.recommendations.getRecommendations('pod_id', { fmtOptions, hiddenFields })],
+    ['quizzes', (c, fmtOptions, hiddenFields) => c.quizzes.getQuizResults('quiz_id', { fmtOptions, hiddenFields, answers: [[1]], quizVersionId: 'v', quizSessionId: 's' })],
+  ];
+
+  cases.forEach(([name, call]) => {
+    it(`does not mutate the caller's fmtOptions object (${name})`, () => {
+      const c = client();
+      const fmtOptions = { fields: ['id', 'name'] };
+      const snapshot = JSON.parse(JSON.stringify(fmtOptions));
+
+      // Fire and ignore the (stubbed) network result; the URL is already built.
+      call(c, fmtOptions, ['price', 'stock'])?.catch?.(() => {});
+
+      expect(fmtOptions).to.deep.equal(snapshot);
+      expect(fmtOptions).to.not.have.property('hidden_fields');
+    });
+  });
+});

--- a/src/modules/autocomplete.js
+++ b/src/modules/autocomplete.js
@@ -94,7 +94,7 @@ function createAutocompleteUrl(query, parameters, options) {
 
     // Pull format options from parameters
     if (fmtOptions) {
-      queryParams.fmt_options = fmtOptions;
+      queryParams.fmt_options = { ...fmtOptions };
     }
 
     // Pull hidden fields from parameters

--- a/src/modules/browse.js
+++ b/src/modules/browse.js
@@ -94,7 +94,7 @@ function createQueryParams(parameters, options) {
 
     // Pull format options from parameters
     if (fmtOptions) {
-      queryParams.fmt_options = fmtOptions;
+      queryParams.fmt_options = { ...fmtOptions };
     }
 
     // Pull hidden fields from parameters

--- a/src/modules/quizzes.js
+++ b/src/modules/quizzes.js
@@ -79,7 +79,7 @@ function createQuizUrl(quizId, parameters, options, path) {
     }
 
     if (fmtOptions) {
-      queryParams.fmt_options = fmtOptions;
+      queryParams.fmt_options = { ...fmtOptions };
     }
 
     if (hiddenFields) {

--- a/src/modules/recommendations.js
+++ b/src/modules/recommendations.js
@@ -87,7 +87,7 @@ function createRecommendationsUrl(podId, parameters, options) {
 
     // Pull format options from parameters
     if (fmtOptions) {
-      queryParams.fmt_options = fmtOptions;
+      queryParams.fmt_options = { ...fmtOptions };
     }
 
     // Pull hidden fields from parameters

--- a/src/modules/search.js
+++ b/src/modules/search.js
@@ -88,7 +88,7 @@ function createSearchUrl(query, parameters, options, isVoiceSearch = false) {
 
     // Pull format options from parameters
     if (fmtOptions) {
-      queryParams.fmt_options = fmtOptions;
+      queryParams.fmt_options = { ...fmtOptions };
     }
 
     // Pull hidden fields from parameters


### PR DESCRIPTION
## Problem

When a request is made with **both** `fmtOptions` and `hiddenFields`, the request builders assign the caller's `fmtOptions` object to `queryParams.fmt_options` **by reference** and then write `hidden_fields` onto it:

```js
if (fmtOptions) {
  queryParams.fmt_options = fmtOptions;          // same reference as the caller's object
}
if (hiddenFields) {
  if (queryParams.fmt_options) {
    queryParams.fmt_options.hidden_fields = hiddenFields;   // <-- mutates the caller's object
  }
}
```

So calling e.g. `getAutocompleteResults` **mutates the object the caller passed in**. Reusing the same `fmtOptions` object across calls silently accumulates a `hidden_fields` key.

### Reproduction

```js
const fmtOptions = { fields: ['id', 'name'] };
client.autocomplete.getAutocompleteResults('shoes', { fmtOptions, hiddenFields: ['price', 'stock'] });
console.log(fmtOptions);
// { fields: ['id','name'], hidden_fields: ['price','stock'] }  ← caller's object was mutated
```

## Fix

Shallow-copy `fmtOptions` on assignment so the serialized request is **identical** while the caller's input is left intact:

```js
queryParams.fmt_options = { ...fmtOptions };
```

Applied to the five modules that exhibit the mutation: **autocomplete, search, browse, recommendations, quizzes**. `agent.js` assigns by reference too but never writes to it, so it is unaffected and left unchanged.

## Tests

Adds `spec/src/modules/fmtOptions-immutability.js` — an offline regression spec (stubbed `fetch`, no API key/network) asserting the caller's `fmtOptions` is not mutated across all five modules. Verified it **fails on the current code** and **passes with the fix**. `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DbUHs855FyBt2J7cG2Qmhh