### PR TITLE
[AT-176]: Add questionTopic parameter to PIA question tracking events

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -15030,6 +15030,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       section: 'Products',
       variationId: '2',
       threadId: 'thread-123',
+      questionTopic: 'pricing',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
@@ -15183,6 +15184,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
         expect(bodyParams).to.have.property('variation_id').to.equal(optionalParameters.variationId);
         expect(bodyParams).to.have.property('thread_id').to.equal(optionalParameters.threadId);
+        expect(bodyParams).to.have.property('question_topic').to.equal(optionalParameters.questionTopic);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');
@@ -15353,6 +15355,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
       section: 'Products',
       variationId: '2',
       threadId: 'thread-123',
+      questionTopic: 'pricing',
     };
 
     it('Should respond with a valid response when term and required parameters are provided', (done) => {
@@ -15506,6 +15509,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(requestParams).to.have.property('section').to.equal(optionalParameters.section);
         expect(bodyParams).to.have.property('variation_id').to.equal(optionalParameters.variationId);
         expect(bodyParams).to.have.property('thread_id').to.equal(optionalParameters.threadId);
+        expect(bodyParams).to.have.property('question_topic').to.equal(optionalParameters.questionTopic);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -3592,7 +3592,7 @@ class Tracker {
    * @param {string} parameters.question - Question a user clicked on
    * @param {string} [parameters.variationId] - Variation id whose page we are on
    * @param {string} [parameters.threadId] - Thread ID for grouping events within a conversation
-   * @param {string} [parameters.questionTopic] - Topic category of the question
+   * @param {string} [parameters.questionTopic] - Topic category of the question.
    * @param {string} [parameters.section] - The section name for the item Ex. "Products"
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -3592,6 +3592,7 @@ class Tracker {
    * @param {string} parameters.question - Question a user clicked on
    * @param {string} [parameters.variationId] - Variation id whose page we are on
    * @param {string} [parameters.threadId] - Thread ID for grouping events within a conversation
+   * @param {string} [parameters.questionTopic] - Topic category of the question
    * @param {string} [parameters.section] - The section name for the item Ex. "Products"
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
@@ -3618,6 +3619,7 @@ class Tracker {
         variationId,
         question,
         threadId,
+        questionTopic,
       } = parameters;
       const queryParams = {};
       const bodyParams = {
@@ -3629,6 +3631,10 @@ class Tracker {
 
       if (threadId) {
         bodyParams.thread_id = threadId;
+      }
+
+      if (questionTopic) {
+        bodyParams.question_topic = questionTopic;
       }
 
       if (section) {
@@ -3666,6 +3672,7 @@ class Tracker {
    * @param {string} parameters.question - Question a user submitted
    * @param {string} [parameters.variationId] - Variation id whose page we are on
    * @param {string} [parameters.threadId] - Thread ID for grouping events within a conversation
+   * @param {string} [parameters.questionTopic] - Topic category of the question
    * @param {string} [parameters.section] - The section name for the item Ex. "Products"
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
@@ -3692,6 +3699,7 @@ class Tracker {
         variationId,
         question,
         threadId,
+        questionTopic,
       } = parameters;
       const queryParams = {};
       const bodyParams = {
@@ -3703,6 +3711,10 @@ class Tracker {
 
       if (threadId) {
         bodyParams.thread_id = threadId;
+      }
+
+      if (questionTopic) {
+        bodyParams.question_topic = questionTopic;
       }
 
       if (section) {

--- a/src/types/tracker.d.ts
+++ b/src/types/tracker.d.ts
@@ -410,6 +410,7 @@ declare class Tracker {
       question: string;
       variationId?: string;
       threadId?: string;
+      questionTopic?: string;
       section?: string;
     },
     networkParameters?: NetworkParameters
@@ -422,6 +423,7 @@ declare class Tracker {
       question: string;
       variationId?: string;
       threadId?: string;
+      questionTopic?: string;
       section?: string;
     },
     networkParameters?: NetworkParameters


### PR DESCRIPTION
LINEAR: https://linear.app/constructor/issue/AT-176/js-client-add-question-topic-to-pia-tracking-events
