### PR TITLE
[CDX-398] Backwards Compatibility Fix for CJS users

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,8 +3,17 @@
   "version": "2.90.0",
   "description": "Constructor.io JavaScript client",
   "main": "lib/constructorio.js",
-  "module": "lib/esm/constructorio.js",
   "types": "lib/types/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/types/index.d.ts",
+      "import": "./lib/esm/constructorio.mjs",
+      "require": "./lib/constructorio.js",
+      "default": "./lib/constructorio.js"
+    },
+    "./lib/*": "./lib/*",
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "clean": "sudo rm -rf node_modules package-lock.json",
     "version": "node ./src/generateVersion.js && npm run docs && git add ./docs/* && npm run bundle && git add -A ./dist && git add ./src/version.js",

--- a/scripts/build-esm.js
+++ b/scripts/build-esm.js
@@ -8,5 +8,7 @@ require('esbuild').build({
   define: {
     global: 'window',
   },
-  outfile: './lib/esm/constructorio.js',
+  // .mjs so Node classifies this as ESM without `"type": "module"`, which would
+  // reclassify every .js in the package and break CJS consumers.
+  outfile: './lib/esm/constructorio.mjs',
 }).catch(() => process.exit(1));


### PR DESCRIPTION
When we released the ESM bundled version earlier, we unintentionally made it the default export. This resulted in CJS environments breaking when they upgraded to the newer minor version since `require` now returns `{ default: xxx }`.

This patch fix removes the typical ESM-structure in package.json in favor of `exports` which allows us to retain the typical `require` pattern while also supporting the usual `import` pattern for ESM. There are limitations however, namely:

1. **Extension-less deep imports are no longer supported**
   1. require('@constructor-io/constructorio-client-javascript/lib/src/modules/search') → MODULE_NOT_FOUND.
   2. Deep imports must also include the extension, i.e. `.js`

2. **Shared types declaration is ambiguous and might fail for `node16` ESM consumers**
    1. Since the JS uses `module.exports` but the types use `export default`, TypeScript under moduleResolution: "node16" might think .default is required when it isn't.
    2. Might need to split types into `.ts` and `.mts`

3. **Older bundlers that do not support `exports` will not work for ESM environments since package.json no longer has the `module` field**
