### PR TITLE
Add source parameter to ASA submit tracking

### DIFF
--- a/spec/src/modules/tracker.js
+++ b/spec/src/modules/tracker.js
@@ -9836,6 +9836,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
     const optionalParameters = {
       section: 'Products',
       threadId: 'thread-1234',
+      source: 'suggestion',
     };
 
     it('Should respond with a valid response when intent and required parameters are provided', (done) => {
@@ -9985,6 +9986,7 @@ describe(`ConstructorIO - Tracker${bundledDescriptionSuffix}`, () => {
         expect(fetchSpy).to.have.been.called;
         expect(requestParams).to.have.property('section').to.equal('Products');
         expect(requestParams).to.have.property('thread_id').to.equal(optionalParameters.threadId);
+        expect(requestParams).to.have.property('source').to.equal(optionalParameters.source);
 
         // Response
         expect(responseParams).to.have.property('method').to.equal('POST');

--- a/src/modules/tracker.js
+++ b/src/modules/tracker.js
@@ -2738,15 +2738,18 @@ class Tracker {
    * @param {string} parameters.intent - Intent of user request
    * @param {string} [parameters.section] - The section name for the item Ex. "Products"
    * @param {string} [parameters.threadId] - Thread ID for grouping events within a conversation
+   * @param {string} [parameters.source] - How the intent was submitted Ex. "suggestion"
    * @param {object} [networkParameters] - Parameters relevant to the network request
    * @param {number} [networkParameters.timeout] - Request timeout (in milliseconds)
    * @returns {(true|Error)}
    * @description User submitted an agent search
-   *   (pressing enter within agent input element, or clicking agent submit element)
+   *   (pressing enter within agent input element, or clicking an agent submit or
+   *   suggested question element)
    * @example
    * constructorio.tracker.trackAgentSubmit(
    *     {
    *         intent: 'show me a recipe for a cookie',
+   *         source: 'suggestion',
    *     },
    * );
    */
@@ -2758,6 +2761,7 @@ class Tracker {
         section,
         intent,
         threadId,
+        source,
       } = parameters;
       const bodyParams = {
         intent,
@@ -2766,6 +2770,10 @@ class Tracker {
 
       if (threadId) {
         bodyParams.thread_id = threadId;
+      }
+
+      if (source) {
+        bodyParams.source = source;
       }
 
       const requestURL = `${baseUrl}${applyParamsAsString({}, this.options)}`;

--- a/src/types/tracker.d.ts
+++ b/src/types/tracker.d.ts
@@ -284,6 +284,7 @@ declare class Tracker {
       intent: string;
       section?: string;
       threadId?: string;
+      source?: string;
     },
     networkParameters?: NetworkParameters
   ): true | Error;


### PR DESCRIPTION
Adds an optional source parameter to trackAgentSubmit / trackAssistantSubmit, forwarded to the behavioral-actions API as source in the request body.