### PR TITLE
[AT-230]: Add follow_up_refinement agent event type

### DIFF
--- a/spec/src/modules/agent.js
+++ b/spec/src/modules/agent.js
@@ -372,7 +372,7 @@ describe(`ConstructorIO - Agent${bundledDescriptionSuffix}`, () => {
         intent_result_id: '5ef345d6-3a36-4c4b-9de4-763d04e294f2',
         thread_id: 'e421aec7-8b2a-4398-847e-08badd0225bc',
         question: 'Who are you shopping for?',
-        options: ["Women's styles", "Men's styles", 'Kids and baby'],
+        options: ['Women\'s styles', 'Men\'s styles', 'Kids and baby'],
       };
 
       setupEventListeners(mockEventSource, mockStreamController, Agent.EventTypes);

--- a/spec/src/modules/agent.js
+++ b/spec/src/modules/agent.js
@@ -366,6 +366,28 @@ describe(`ConstructorIO - Agent${bundledDescriptionSuffix}`, () => {
         done();
       });
     });
+    it('should enqueue FOLLOW_UP_REFINEMENT event data into the stream', (done) => {
+      const eventType = Agent.EventTypes.FOLLOW_UP_REFINEMENT;
+      const eventData = {
+        intent_result_id: '5ef345d6-3a36-4c4b-9de4-763d04e294f2',
+        thread_id: 'e421aec7-8b2a-4398-847e-08badd0225bc',
+        question: 'Who are you shopping for?',
+        options: ["Women's styles", "Men's styles", 'Kids and baby'],
+      };
+
+      setupEventListeners(mockEventSource, mockStreamController, Agent.EventTypes);
+
+      const refinementCallback = mockEventSource.addEventListener
+        .getCalls()
+        .find((call) => call.args[0] === eventType).args[1];
+
+      refinementCallback({ data: JSON.stringify(eventData) });
+
+      setImmediate(() => {
+        expect(mockStreamController.enqueue.calledWith({ type: eventType, data: eventData })).to.be.true;
+        done();
+      });
+    });
   });
 
   describe('getAgentResultsStream', () => {

--- a/src/modules/agent.js
+++ b/src/modules/agent.js
@@ -172,6 +172,7 @@ class Agent {
     IMAGE_META: 'image_meta', // This event type is used for enhancing recommendations with media content such as images
     MESSAGE: 'message', // Represents a textual message from the agent
     FOLLOW_UP_QUESTIONS: 'follow_up_questions', // Represents follow-up question suggestions
+    FOLLOW_UP_REFINEMENT: 'follow_up_refinement', // Represents a narrowing question with selectable options
     END: 'end', // Represents the end of data stream
   };
 

--- a/src/types/agent.d.ts
+++ b/src/types/agent.d.ts
@@ -20,8 +20,32 @@ export interface IAgentParameters {
   fmtOptions?: Pick<FmtOptions, 'fields' | 'hidden_fields'>;
 }
 
+export interface AgentEventTypes {
+  START: 'start';
+  GROUP: 'group';
+  SEARCH_RESULT: 'search_result';
+  ARTICLE_REFERENCE: 'article_reference';
+  RECIPE_INFO: 'recipe_info';
+  RECIPE_INSTRUCTIONS: 'recipe_instructions';
+  SERVER_ERROR: 'server_error';
+  IMAGE_META: 'image_meta';
+  MESSAGE: 'message';
+  FOLLOW_UP_QUESTIONS: 'follow_up_questions';
+  FOLLOW_UP_REFINEMENT: 'follow_up_refinement';
+  END: 'end';
+}
+
+export interface FollowUpRefinementEventData {
+  intent_result_id?: string;
+  thread_id?: string;
+  question: string;
+  options: string[];
+}
+
 declare class Agent {
   constructor(options: ConstructorClientOptions);
+
+  static EventTypes: AgentEventTypes;
 
   options: ConstructorClientOptions;
 


### PR DESCRIPTION
The agent now emits a `follow_up_refinement` SSE event (a narrowing question with
selectable options). The Agent module only subscribes to event types listed in
`Agent.EventTypes`, so the event was silently dropped from the stream.